### PR TITLE
`MockFheOps.sol`: update `random`, `bytes32ToBytes`, and `decrypt`

### DIFF
--- a/contracts/utils/debug/MockFheOps.sol
+++ b/contracts/utils/debug/MockFheOps.sol
@@ -37,41 +37,22 @@ contract MockFheOps {
             result = uint256(type(uint128).max) + 1;
         } else if (utype == 5) {
             result = 1;
-        } else if (utype > 5 && utype < 12) {
-            revert("Unsupported type");
         } else if (utype == 12) {
             result = uint256(type(uint160).max) + 1; //address
         } else if (utype == 13) {
             result = 1; //bool (we want anything non-zero to be false)
         } else {
-            revert("Unsupported type"); 
+            revert("Unsupported type");
         }
 
         return result;
     }
-    
-    function bytes32ToBytes(bytes32 input, uint8 utype) internal pure returns (bytes memory) {
-        uint256 length; 
-        if (utype == 0) length = 1;  // uint8
-        else if (utype == 1) length = 2;  // uint16
-        else if (utype == 2) length = 4;  // uint32
-        else if (utype == 3) length = 8;  // uint64
-        else if (utype == 4) length = 16; // uint128
-        else if (utype == 5) length = 32; //uint256
-        else if (utype > 5 && utype <= 11) revert("Unsupported type"); // uint256
-        else if (utype == 12) length = 20; // uint160
-        else if (utype == 13) length = 1; // bool (uint8)
-        else revert("Unsupported type");
 
-        // Always return 32 bytes
-        bytes memory result = new bytes(32);
-
-        // Copy the relevant bytes from bytes32 to the result
-        for (uint256 i = 0; i < length; i++) {
-            result[32 - length + i] = input[length + i]; // Align to the right (most significant bytes)
-        }   
-
-        return result;
+    function bytes32ToBytes(
+        bytes32 input,
+        uint8
+    ) internal pure returns (bytes memory) {
+        return bytes.concat(input);
     }
 
     //For converting back to bytes
@@ -79,7 +60,7 @@ contract MockFheOps {
         bytes memory result = new bytes(32);
 
         assembly {
-        mstore(add(result, 32), value) 
+            mstore(add(result, 32), value)
         }
 
         return result;
@@ -98,9 +79,15 @@ contract MockFheOps {
     }
 
     //for unknown size of bytes - we could instead just encode it as bytes32 because it's always uint256 but for now lets keep it like this
-    function bytesToUint(bytes memory b) internal pure virtual returns (uint256) {
+    function bytesToUint(
+        bytes memory b
+    ) internal pure virtual returns (uint256) {
         require(b.length <= 32, "Bytes length exceeds 32.");
-        return abi.decode(abi.encodePacked(new bytes(32 - b.length), b), (uint256));
+        return
+            abi.decode(
+                abi.encodePacked(new bytes(32 - b.length), b),
+                (uint256)
+            );
     }
 
     function bytesToBool(bytes memory b) internal pure virtual returns (bool) {
@@ -109,156 +96,280 @@ contract MockFheOps {
         return value != 0;
     }
 
-    function trivialEncrypt(bytes memory input, uint8 toType, int32) external pure returns (bytes memory) {
+    function trivialEncrypt(
+        bytes memory input,
+        uint8 toType,
+        int32
+    ) external pure returns (bytes memory) {
         bytes32 result = bytes32(input);
         return bytes32ToBytes(result, toType);
     }
 
-    function add(uint8 utype, bytes memory lhsHash, bytes memory rhsHash) external pure returns (bytes memory) {
-        uint256 result = (bytesToUint(lhsHash) + bytesToUint(rhsHash)) % maxValue(utype);
+    function add(
+        uint8 utype,
+        bytes memory lhsHash,
+        bytes memory rhsHash
+    ) external pure returns (bytes memory) {
+        uint256 result = (bytesToUint(lhsHash) + bytesToUint(rhsHash)) %
+            maxValue(utype);
         return uint256ToBytes(result);
     }
 
-    function sealOutput(uint8, bytes memory ctHash, bytes memory) external pure returns (string memory) {
+    function sealOutput(
+        uint8,
+        bytes memory ctHash,
+        bytes memory
+    ) external pure returns (string memory) {
         return string(ctHash);
     }
 
-    function verify(uint8, bytes memory input, int32) external pure returns (bytes memory) {
+    function verify(
+        uint8,
+        bytes memory input,
+        int32
+    ) external pure returns (bytes memory) {
         return input;
     }
 
-    function cast(uint8, bytes memory input, uint8 toType) external pure returns (bytes memory) {
+    function cast(
+        uint8,
+        bytes memory input,
+        uint8 toType
+    ) external pure returns (bytes memory) {
         bytes32 result = bytes32(input);
         return bytes32ToBytes(result, toType);
     }
 
     function log(string memory s) external pure {}
 
-    function decrypt(uint8, bytes memory input) external pure returns (uint256) {
+    function decrypt(
+        uint8,
+        bytes memory input,
+        uint256
+    ) external pure returns (uint256) {
         uint256 result = bytesToUint(input);
         return result;
     }
 
-    function lte(uint8 utype, bytes memory lhsHash, bytes memory rhsHash) external pure returns (bytes memory)    {
-        bool result = (bytesToUint(lhsHash) % maxValue(utype)) <= (bytesToUint(rhsHash) % maxValue(utype));
+    function lte(
+        uint8 utype,
+        bytes memory lhsHash,
+        bytes memory rhsHash
+    ) external pure returns (bytes memory) {
+        bool result = (bytesToUint(lhsHash) % maxValue(utype)) <=
+            (bytesToUint(rhsHash) % maxValue(utype));
         return boolToBytes(result);
     }
 
-    function sub(uint8 utype, bytes memory lhsHash, bytes memory rhsHash) external pure returns (bytes memory)    {
-        uint256 result = (bytesToUint(lhsHash) - bytesToUint(rhsHash)) % maxValue(utype);
+    function sub(
+        uint8 utype,
+        bytes memory lhsHash,
+        bytes memory rhsHash
+    ) external pure returns (bytes memory) {
+        uint256 result = (bytesToUint(lhsHash) - bytesToUint(rhsHash)) %
+            maxValue(utype);
         return uint256ToBytes(result);
     }
 
-    function mul(uint8 utype, bytes memory lhsHash, bytes memory rhsHash) external pure returns (bytes memory)    {
-        uint256 result = (bytesToUint(lhsHash) * bytesToUint(rhsHash)) % maxValue(utype);
+    function mul(
+        uint8 utype,
+        bytes memory lhsHash,
+        bytes memory rhsHash
+    ) external pure returns (bytes memory) {
+        uint256 result = (bytesToUint(lhsHash) * bytesToUint(rhsHash)) %
+            maxValue(utype);
         return uint256ToBytes(result);
     }
 
-    function lt(uint8 utype, bytes memory lhsHash, bytes memory rhsHash) external pure returns (bytes memory)    {
-        bool result = (bytesToUint(lhsHash) % maxValue(utype)) < (bytesToUint(rhsHash) % maxValue(utype));
+    function lt(
+        uint8 utype,
+        bytes memory lhsHash,
+        bytes memory rhsHash
+    ) external pure returns (bytes memory) {
+        bool result = (bytesToUint(lhsHash) % maxValue(utype)) <
+            (bytesToUint(rhsHash) % maxValue(utype));
         return boolToBytes(result);
     }
 
-    function select(uint8, bytes memory controlHash, bytes memory ifTrueHash, bytes memory ifFalseHash) external pure returns (bytes memory)    {
+    function select(
+        uint8,
+        bytes memory controlHash,
+        bytes memory ifTrueHash,
+        bytes memory ifFalseHash
+    ) external pure returns (bytes memory) {
         bool control = bytesToBool(controlHash);
         if (control) return ifTrueHash;
         return ifFalseHash;
     }
 
-    function req(uint8, bytes memory input) external pure returns (bytes memory)    {
+    function req(
+        uint8,
+        bytes memory input
+    ) external pure returns (bytes memory) {
         return input;
     }
 
-    function div(uint8 utype, bytes memory lhsHash, bytes memory rhsHash) external pure returns (bytes memory)    {
-       uint256 result = (bytesToUint(lhsHash) / bytesToUint(rhsHash)) % maxValue(utype);
+    function div(
+        uint8 utype,
+        bytes memory lhsHash,
+        bytes memory rhsHash
+    ) external pure returns (bytes memory) {
+        uint256 result = (bytesToUint(lhsHash) / bytesToUint(rhsHash)) %
+            maxValue(utype);
         return uint256ToBytes(result);
     }
 
-    function gt(uint8 utype, bytes memory lhsHash, bytes memory rhsHash) external pure returns (bytes memory)    {
-        bool result = (bytesToUint(lhsHash) % maxValue(utype)) > (bytesToUint(rhsHash) % maxValue(utype));
+    function gt(
+        uint8 utype,
+        bytes memory lhsHash,
+        bytes memory rhsHash
+    ) external pure returns (bytes memory) {
+        bool result = (bytesToUint(lhsHash) % maxValue(utype)) >
+            (bytesToUint(rhsHash) % maxValue(utype));
         return boolToBytes(result);
     }
 
-    function gte(uint8 utype, bytes memory lhsHash, bytes memory rhsHash) external pure returns (bytes memory)    {
-        bool result = (bytesToUint(lhsHash) % maxValue(utype)) >= (bytesToUint(rhsHash) % maxValue(utype));
+    function gte(
+        uint8 utype,
+        bytes memory lhsHash,
+        bytes memory rhsHash
+    ) external pure returns (bytes memory) {
+        bool result = (bytesToUint(lhsHash) % maxValue(utype)) >=
+            (bytesToUint(rhsHash) % maxValue(utype));
         return boolToBytes(result);
     }
 
-    function rem(uint8 utype, bytes memory lhsHash, bytes memory rhsHash) external pure returns (bytes memory)    {
-       uint256 result = (bytesToUint(lhsHash) % bytesToUint(rhsHash)) % maxValue(utype);
+    function rem(
+        uint8 utype,
+        bytes memory lhsHash,
+        bytes memory rhsHash
+    ) external pure returns (bytes memory) {
+        uint256 result = (bytesToUint(lhsHash) % bytesToUint(rhsHash)) %
+            maxValue(utype);
         return uint256ToBytes(result);
     }
 
-    function and(uint8 utype, bytes memory lhsHash, bytes memory rhsHash) external pure returns (bytes memory)    {
+    function and(
+        uint8 utype,
+        bytes memory lhsHash,
+        bytes memory rhsHash
+    ) external pure returns (bytes memory) {
         bytes32 result = bytes32(lhsHash) & bytes32(rhsHash);
         return bytes32ToBytes(result, utype);
     }
-    
-    function or(uint8 utype, bytes memory lhsHash, bytes memory rhsHash) external pure returns (bytes memory)    {
+
+    function or(
+        uint8 utype,
+        bytes memory lhsHash,
+        bytes memory rhsHash
+    ) external pure returns (bytes memory) {
         bytes32 result = bytes32(lhsHash) | bytes32(rhsHash);
         return bytes32ToBytes(result, utype);
     }
 
-    function xor(uint8 utype, bytes memory lhsHash, bytes memory rhsHash) external pure returns (bytes memory)    {
+    function xor(
+        uint8 utype,
+        bytes memory lhsHash,
+        bytes memory rhsHash
+    ) external pure returns (bytes memory) {
         bytes32 result = bytes32(lhsHash) ^ bytes32(rhsHash);
         return bytes32ToBytes(result, utype);
     }
 
-    function eq(uint8 utype, bytes memory lhsHash, bytes memory rhsHash) external pure returns (bytes memory)    {
-        bool result = (bytesToUint(lhsHash) % maxValue(utype)) == (bytesToUint(rhsHash) % maxValue(utype));
+    function eq(
+        uint8 utype,
+        bytes memory lhsHash,
+        bytes memory rhsHash
+    ) external pure returns (bytes memory) {
+        bool result = (bytesToUint(lhsHash) % maxValue(utype)) ==
+            (bytesToUint(rhsHash) % maxValue(utype));
         return boolToBytes(result);
     }
 
-    function ne(uint8 utype, bytes memory lhsHash, bytes memory rhsHash) external pure returns (bytes memory)    {
-        bool result = (bytesToUint(lhsHash) % maxValue(utype)) != (bytesToUint(rhsHash) % maxValue(utype));
+    function ne(
+        uint8 utype,
+        bytes memory lhsHash,
+        bytes memory rhsHash
+    ) external pure returns (bytes memory) {
+        bool result = (bytesToUint(lhsHash) % maxValue(utype)) !=
+            (bytesToUint(rhsHash) % maxValue(utype));
         return boolToBytes(result);
     }
 
-    function min(uint8 utype, bytes memory lhsHash, bytes memory rhsHash) external pure returns (bytes memory)    {
-        bool result = (bytesToUint(lhsHash) % maxValue(utype)) >= (bytesToUint(rhsHash) % maxValue(utype));
+    function min(
+        uint8 utype,
+        bytes memory lhsHash,
+        bytes memory rhsHash
+    ) external pure returns (bytes memory) {
+        bool result = (bytesToUint(lhsHash) % maxValue(utype)) >=
+            (bytesToUint(rhsHash) % maxValue(utype));
         if (result == true) {
             return rhsHash;
         }
         return lhsHash;
     }
 
-    function max(uint8 utype, bytes memory lhsHash, bytes memory rhsHash) external pure returns (bytes memory)    {
-        bool result = (bytesToUint(lhsHash) % maxValue(utype)) >= (bytesToUint(rhsHash) % maxValue(utype));
+    function max(
+        uint8 utype,
+        bytes memory lhsHash,
+        bytes memory rhsHash
+    ) external pure returns (bytes memory) {
+        bool result = (bytesToUint(lhsHash) % maxValue(utype)) >=
+            (bytesToUint(rhsHash) % maxValue(utype));
         if (result == true) {
             return lhsHash;
         }
         return rhsHash;
     }
 
-    function shl(uint8, bytes memory lhsHash, bytes memory rhsHash) external pure returns (bytes memory)    {
+    function shl(
+        uint8,
+        bytes memory lhsHash,
+        bytes memory rhsHash
+    ) external pure returns (bytes memory) {
         uint256 lhs = bytesToUint(lhsHash);
         uint256 rhs = bytesToUint(rhsHash);
-    
+
         uint256 result = lhs << rhs;
-         
+
         return uint256ToBytes(result);
     }
 
-    function shr(uint8, bytes memory lhsHash, bytes memory rhsHash) external pure returns (bytes memory)    {
+    function shr(
+        uint8,
+        bytes memory lhsHash,
+        bytes memory rhsHash
+    ) external pure returns (bytes memory) {
         uint256 lhs = bytesToUint(lhsHash);
         uint256 rhs = bytesToUint(rhsHash);
-    
+
         uint256 result = lhs >> rhs;
-    
+
         return uint256ToBytes(result);
     }
 
-    function not(uint8 utype, bytes memory value) external pure returns (bytes memory)    {
+    function not(
+        uint8 utype,
+        bytes memory value
+    ) external pure returns (bytes memory) {
         bytes32 result = ~bytes32(value);
         return bytes32ToBytes(result, utype);
     }
 
-    function getNetworkPublicKey(int32) external pure returns (bytes memory)    {
-        string memory x = "((-(-_(-_-)_-)-)) You've stepped into the wrong neighborhood pal.";
+    function getNetworkPublicKey(int32) external pure returns (bytes memory) {
+        string
+            memory x = "((-(-_(-_-)_-)-)) You've stepped into the wrong neighborhood pal.";
         return bytes(x);
     }
 
-    function random(uint8 utype, uint64, int32) external pure returns (bytes memory) {
-        return uint256ToBytes(maxValue(utype));
+    function random(
+        uint8 utype,
+        uint64,
+        int32
+    ) external view returns (bytes memory) {
+        return
+            uint256ToBytes(
+                uint(keccak256(abi.encode(block.timestamp))) % maxValue(utype)
+            );
     }
 }


### PR DESCRIPTION
Updates:
`random`: Now creates a pseudorandom number instead of the max uint value
`bytes32ToBytes`: This was returning 0 for all values, replaced with a simplified version that doesn't care about the uint type
`decrypt`: Updated to match the signature in `FheOS.sol` and prevent reversion

Sorry about the linting :/