### PR TITLE
DISCUSSION - PermitV2 and PermissionV2

### DIFF
--- a/contracts/draft/JsonBuilder.sol
+++ b/contracts/draft/JsonBuilder.sol
@@ -1,0 +1,193 @@
+// solhint-disable quotes
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.19 <0.9.0;
+
+import {Strings} from "@openzeppelin/contracts/utils/Strings.sol";
+import {Base64} from "@openzeppelin/contracts/utils/Base64.sol";
+
+/**
+ * @dev Library to help build structured JSON strings.
+ * Optionally the JSON can be converted into base64 as the final step.
+ * - Architect
+ *
+ * Usage:
+ *
+ * JsonBuilder
+ *   .obj()
+ *   .kv("name", symbol())
+ *   .kv("description", name())
+ *   .kv("attributes", attributes, false)
+ *   .end()
+ *   .toBase64();
+ *
+ */
+library JsonBuilder {
+    function obj() internal pure returns (string memory) {
+        return "";
+    }
+
+    function end(string memory o) internal pure returns (string memory) {
+        return inBraces(o);
+    }
+
+    function addressToString(
+        address _address
+    ) internal pure returns (string memory) {
+        bytes32 _bytes = bytes32(uint256(uint160(_address)));
+        bytes memory _hex = "0123456789abcdef";
+        bytes memory _string = new bytes(42);
+        _string[0] = "0";
+        _string[1] = "x";
+        for (uint256 i = 0; i < 20; i++) {
+            _string[2 + i * 2] = _hex[uint8(_bytes[i + 12] >> 4)];
+            _string[3 + i * 2] = _hex[uint8(_bytes[i + 12] & 0x0f)];
+        }
+        return string(_string);
+    }
+
+    function inQuotes(string memory val) internal pure returns (string memory) {
+        return string.concat('"', val, '"');
+    }
+    function inBraces(string memory val) internal pure returns (string memory) {
+        return string.concat("{", val, "}");
+    }
+    function inBrackets(
+        string memory val
+    ) internal pure returns (string memory) {
+        return string.concat("[", val, "]");
+    }
+    function toCommaSeparatedList(
+        string[] memory vals
+    ) internal pure returns (string memory result) {
+        result = "";
+        for (uint256 i = 0; i < vals.length; i++) {
+            result = string.concat(
+                result,
+                vals[i],
+                i < vals.length - 1 ? "," : ""
+            );
+        }
+    }
+
+    function bytes32ToString(
+        bytes32 _bytes32
+    ) internal pure returns (string memory) {
+        uint8 i = 0;
+        while (i < 32 && _bytes32[i] != 0) {
+            i++;
+        }
+        bytes memory bytesArray = new bytes(i);
+        for (i = 0; i < 32 && _bytes32[i] != 0; i++) {
+            bytesArray[i] = _bytes32[i];
+        }
+        return string(bytesArray);
+    }
+
+    function kv(
+        string memory o,
+        string memory key,
+        string memory value
+    ) internal pure returns (string memory) {
+        return kv(o, key, value, true);
+    }
+    function kv(
+        string memory o,
+        string memory key,
+        address value
+    ) internal pure returns (string memory) {
+        return kv(o, key, addressToString(value), true);
+    }
+    function kv(
+        string memory o,
+        string memory key,
+        bool value
+    ) internal pure returns (string memory) {
+        return kv(o, key, value ? "true" : "false", true);
+    }
+    function kv(
+        string memory o,
+        string memory key,
+        uint256 value
+    ) internal pure returns (string memory) {
+        return kv(o, key, Strings.toString(value), true);
+    }
+
+    function kv(
+        string memory o,
+        string memory key,
+        string[] memory values
+    ) internal pure returns (string memory) {
+        return kv(o, key, inBrackets(toCommaSeparatedList(values)), false);
+    }
+    function kv(
+        string memory o,
+        string memory key,
+        bytes32[] memory values
+    ) internal pure returns (string memory) {
+        string[] memory bytes32Strings = new string[](values.length);
+        for (uint256 i = 0; i < values.length; i++) {
+            bytes32Strings[i] = inQuotes(bytes32ToString(values[i]));
+        }
+        return
+            kv(o, key, inBrackets(toCommaSeparatedList(bytes32Strings)), false);
+    }
+    function kv(
+        string memory o,
+        string memory key,
+        address[] memory values
+    ) internal pure returns (string memory) {
+        string[] memory addStrings = new string[](values.length);
+        for (uint256 i = 0; i < values.length; i++) {
+            addStrings[i] = inQuotes(addressToString(values[i]));
+        }
+        return kv(o, key, inBrackets(toCommaSeparatedList(addStrings)), false);
+    }
+    function kv(
+        string memory o,
+        string memory key,
+        uint256[] memory values
+    ) internal pure returns (string memory) {
+        string[] memory uintStrings = new string[](values.length);
+        for (uint256 i = 0; i < values.length; i++) {
+            uintStrings[i] = inQuotes(Strings.toString(values[i]));
+        }
+        return kv(o, key, inBrackets(toCommaSeparatedList(uintStrings)), false);
+    }
+
+    function kv(
+        string memory o,
+        string memory key,
+        string memory value,
+        bool quoteValue
+    ) internal pure returns (string memory) {
+        return
+            string.concat(
+                o,
+                bytes(o).length > 0 ? "," : "",
+                '"',
+                key,
+                '":',
+                quoteValue ? '"' : "",
+                value,
+                quoteValue ? '"' : ""
+            );
+    }
+
+    function toBase64(
+        string memory value
+    ) internal pure returns (string memory) {
+        return
+            string(
+                abi.encodePacked(
+                    "data:application/json;base64,",
+                    Base64.encode(bytes(abi.encodePacked(value)))
+                )
+            );
+    }
+
+    function toBase64(
+        string[] memory values
+    ) internal pure returns (string memory) {
+        return toBase64(inBraces(toCommaSeparatedList(values)));
+    }
+}

--- a/contracts/draft/PermissionedV2.sol
+++ b/contracts/draft/PermissionedV2.sol
@@ -1,0 +1,46 @@
+// solhint-disable var-name-mixedcase
+// SPDX-License-Identifier: BSD-3-Clause-Clear
+pragma solidity >=0.8.19 <0.9.0;
+
+import { IFhenixPermitV2, PermissionV2, IFhenixPermissionedV2 } from "./PermitV2.sol";
+
+abstract contract PermissionedV2 is IFhenixPermissionedV2 {
+	bytes32 private projectId;
+
+	IFhenixPermitV2 public PERMIT_V2;
+	string public PROJECT_ID;
+
+	error ProjectNameTooLong();
+
+	constructor(address _permitV2, string memory _projectId) {
+		if (bytes(_projectId).length > 32) revert ProjectNameTooLong();
+
+		PERMIT_V2 = IFhenixPermitV2(_permitV2);
+		projectId = bytes32(abi.encodePacked(_projectId));
+		PROJECT_ID = _projectId;
+
+		PERMIT_V2.validateProjectId(projectId);
+	}
+
+	function checkPermitSatisfies(
+		uint256 _permitId
+	) public view returns (bool) {
+		return
+			PERMIT_V2.checkPermitSatisfies(_permitId, address(this), projectId);
+	}
+
+	/**
+	 * @dev Validates that sender has the permit and permission to view `issuers` data
+	 * Validates that the PermitNFT is in the senders wallet and has access
+	 * to read this contract (via address, project, or category).
+	 */
+	modifier withPermission(PermissionV2 memory permission) {
+		PERMIT_V2.validatePermission(
+			permission,
+			msg.sender,
+			address(this),
+			projectId
+		);
+		_;
+	}
+}

--- a/contracts/draft/PermitV2.sol
+++ b/contracts/draft/PermitV2.sol
@@ -1,0 +1,379 @@
+// solhint-disable func-name-mixedcase
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.19 <0.9.0;
+
+import {ERC721} from "@openzeppelin/contracts/token/ERC721/ERC721.sol";
+import {ERC721Enumerable} from "@openzeppelin/contracts/token/ERC721/extensions/ERC721Enumerable.sol";
+import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
+import {EIP712} from "@openzeppelin/contracts/utils/cryptography/EIP712.sol";
+import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+import {JsonBuilder} from "./JsonBuilder.sol";
+
+struct PermissionV2 {
+    address issuer;
+    uint256 permitId;
+    bytes32 publicKey;
+    bytes signature;
+}
+
+struct PermitV2Info {
+    uint256 id;
+    address issuer;
+    string name;
+    uint64 createdAt;
+    uint64 validityDur;
+    uint64 expiresAt;
+    bool fineGrained;
+    bool revoked;
+}
+
+struct PermitV2FullInfo {
+    uint256 id;
+    address issuer;
+    string name;
+    address holder;
+    uint64 createdAt;
+    uint64 validityDur;
+    uint64 expiresAt;
+    bool fineGrained;
+    bool revoked;
+    address[] contracts;
+    string[] projectIds;
+}
+
+interface IFhenixPermitV2 {
+    function validateProjectId(bytes32 _projectId) external view;
+    function checkPermitSatisfies(
+        uint256 _permitId,
+        address _contract,
+        bytes32 _projectId
+    ) external view returns (bool);
+    function validatePermission(
+        PermissionV2 calldata _permission,
+        address _sender,
+        address _contract,
+        bytes32 _projectId
+    ) external view;
+}
+
+interface IFhenixPermissionedV2 {
+    function PROJECT_ID() external view returns (string memory);
+}
+
+contract PermitV2 is ERC721Enumerable, EIP712, IFhenixPermitV2 {
+    using JsonBuilder for string;
+
+    using EnumerableSet for EnumerableSet.Bytes32Set;
+    using EnumerableSet for EnumerableSet.AddressSet;
+
+    string public version = "v2.0.0";
+
+    uint256 private _pid = 0;
+    mapping(uint256 => PermitV2Info) private permitInfo;
+    mapping(uint256 => EnumerableSet.AddressSet) private permitContracts;
+    mapping(uint256 => EnumerableSet.Bytes32Set) private permitProjectIds;
+
+    EnumerableSet.Bytes32Set private projectIds;
+
+    constructor()
+        ERC721(
+            string.concat("Fhenix Permit ", version),
+            string.concat("fhenix-permit-", version)
+        )
+        EIP712(string.concat("Fhenix Permission ", version), version)
+    {
+        projectIds.add(bytes32(abi.encodePacked("FHERC20")));
+    }
+
+    event PermitV2Created(address indexed user, uint256 indexed permitId);
+
+    error Unauthorized();
+    error InvalidProjectId();
+    error InvalidContractAddress();
+    error PermitIsFineGrained();
+    error PermitIsCoarseGrained();
+
+    error UnauthorizedPermitUsage();
+    error PermitRevoked();
+    error PermitExpired();
+    error PermitOwnerUnauthorized();
+    error PermitCategoryUnauthorized();
+    error PermitContractUnauthorized();
+
+    error SignerNotMessageSender();
+
+    modifier permitIssuedBySender(uint256 _permitId) {
+        if (permitInfo[_permitId].issuer != msg.sender) revert Unauthorized();
+        _;
+    }
+    modifier permitIsActive(uint256 _permitId) {
+        if (permitInfo[_permitId].revoked) revert PermitRevoked();
+        if (permitInfo[_permitId].expiresAt < block.timestamp)
+            revert PermitExpired();
+        _;
+    }
+    modifier permitIsFineGrained(uint256 _permitId) {
+        if (permitInfo[_permitId].fineGrained) revert PermitIsCoarseGrained();
+        _;
+    }
+    modifier permitIsCoarseGrained(uint256 _permitId) {
+        if (!permitInfo[_permitId].fineGrained) revert PermitIsFineGrained();
+        _;
+    }
+    modifier projectIdIsValid(bytes32 _projectId) {
+        if (!projectIds.contains(_projectId)) revert InvalidProjectId();
+        _;
+    }
+    modifier contractIsValid(address _contract) {
+        if (_contract == address(0)) revert InvalidContractAddress();
+        _;
+    }
+
+    function createNewProject(string calldata _projectName) external {
+        if (bytes(_projectName).length > 32) revert InvalidProjectId();
+        bytes32 _projectId = bytes32(abi.encodePacked(_projectName));
+        if (projectIds.contains(_projectId)) revert InvalidProjectId();
+        projectIds.add(_projectId);
+    }
+
+    function createNewPermit(
+        string calldata _name,
+        uint64 _validityDur,
+        bool _fineGrained,
+        address[] calldata _contracts,
+        string[] calldata _projects
+    ) external {
+        _pid += 1;
+
+        permitInfo[_pid] = PermitV2Info({
+            id: _pid,
+            issuer: msg.sender,
+            name: _name,
+            createdAt: uint64(block.timestamp),
+            validityDur: _validityDur,
+            expiresAt: uint64(block.timestamp) + _validityDur,
+            fineGrained: _fineGrained,
+            revoked: false
+        });
+
+        // Add specific contracts to fine grained permit
+        if (_fineGrained) {
+            for (uint256 i = 0; i < _contracts.length; i++) {
+                permitContracts[_pid].add(_contracts[i]);
+            }
+        }
+
+        // Add categories to coarse permit
+        if (!_fineGrained) {
+            for (uint256 i = 0; i < _projects.length; i++) {
+                permitProjectIds[_pid].add(
+                    bytes32(abi.encodePacked(_projects[i]))
+                );
+            }
+        }
+
+        _safeMint(msg.sender, _pid);
+
+        emit PermitV2Created(msg.sender, _pid);
+    }
+
+    function renewPermit(
+        uint256 _permitId
+    ) external permitIssuedBySender(_permitId) {
+        permitInfo[_permitId].expiresAt =
+            uint64(block.timestamp) +
+            permitInfo[_permitId].validityDur;
+    }
+
+    function revokePermit(
+        uint256 _permitId
+    ) external permitIssuedBySender(_permitId) {
+        permitInfo[_permitId].revoked = true;
+    }
+
+    function updateProjectIds(
+        uint256 _permitId,
+        bytes32[] calldata _projectsToAdd,
+        bytes32[] calldata _projectsToRemove
+    )
+        external
+        permitIssuedBySender(_permitId)
+        permitIsCoarseGrained(_permitId)
+    {
+        for (uint256 i = 0; i < _projectsToAdd.length; i++) {
+            permitProjectIds[_permitId].add(
+                bytes32(abi.encodePacked(_projectsToAdd[i]))
+            );
+        }
+
+        for (uint256 i = 0; i < _projectsToRemove.length; i++) {
+            permitProjectIds[_permitId].remove(
+                bytes32(abi.encodePacked(_projectsToRemove[i]))
+            );
+        }
+    }
+
+    function updateContracts(
+        uint256 _permitId,
+        address[] calldata _contractsToAdd,
+        address[] calldata _contractsToRemove
+    ) external permitIssuedBySender(_permitId) permitIsFineGrained(_permitId) {
+        for (uint256 i = 0; i < _contractsToAdd.length; i++) {
+            if (_contractsToAdd[i] == address(0))
+                revert InvalidContractAddress();
+            permitContracts[_permitId].add(_contractsToAdd[i]);
+        }
+
+        for (uint256 i = 0; i < _contractsToRemove.length; i++) {
+            if (_contractsToRemove[i] == address(0))
+                revert InvalidContractAddress();
+            permitContracts[_permitId].remove(_contractsToRemove[i]);
+        }
+    }
+
+    function validateProjectId(bytes32 _projectId) external view {
+        if (!projectIds.contains(_projectId)) revert InvalidProjectId();
+    }
+
+    function checkPermitSatisfies(
+        uint256 _permitId,
+        address _contract,
+        bytes32 _projectId
+    ) external view returns (bool) {
+        if (permitInfo[_permitId].fineGrained) {
+            if (_contract == address(0)) return false;
+            if (!permitContracts[_permitId].contains(_contract)) return false;
+        }
+
+        if (!permitInfo[_permitId].fineGrained) {
+            if (!projectIds.contains(_projectId)) return false;
+            if (!permitProjectIds[_permitId].contains(_projectId)) return false;
+        }
+
+        return true;
+    }
+
+    function validatePermission(
+        PermissionV2 calldata _permission,
+        address _sender,
+        address _contract,
+        bytes32 _projectId
+    ) external view permitIsActive(_permission.permitId) {
+        uint256 permitId = _permission.permitId;
+
+        bytes32 digest = _hashTypedDataV4(
+            keccak256(
+                abi.encode(
+                    keccak256(
+                        "PermissionedV2(address issuer,uint256 permitId,bytes32 publicKey)"
+                    ),
+                    _permission.issuer,
+                    _permission.permitId,
+                    _permission.publicKey
+                )
+            )
+        );
+        address signer = ECDSA.recover(digest, _permission.signature);
+        if (signer != _sender) revert SignerNotMessageSender();
+
+        if (ownerOf(permitId) != signer) revert UnauthorizedPermitUsage();
+        if (permitInfo[permitId].issuer != _permission.issuer)
+            revert Unauthorized();
+
+        if (permitInfo[permitId].fineGrained) {
+            if (!permitContracts[permitId].contains(_contract))
+                revert PermitContractUnauthorized();
+        } else {
+            if (!permitProjectIds[permitId].contains(_projectId))
+                revert PermitCategoryUnauthorized();
+        }
+    }
+
+    function permitSatisfiesContract(
+        uint256 _permitId,
+        address _contract
+    ) external view returns (bool) {
+        PermitV2Info memory _permit = permitInfo[_permitId];
+
+        // Fine grained
+        if (_permit.fineGrained) {
+            return permitContracts[_permitId].contains(_contract);
+        }
+
+        // Coarse grained
+        (bool success, bytes memory result) = _contract.staticcall(
+            abi.encodeWithSelector(IFhenixPermissionedV2.PROJECT_ID.selector)
+        );
+
+        if (!success || result.length == 0) return false;
+
+        bytes32 projectId = abi.decode(result, (bytes32));
+        return permitProjectIds[_permitId].contains(projectId);
+    }
+
+    function tokenURI(
+        uint256 _permitId
+    ) public view override returns (string memory) {
+        PermitV2Info memory _permit = permitInfo[_permitId];
+
+        string memory attributes = JsonBuilder.obj();
+        attributes = attributes.kv("id", _permit.id);
+        attributes = attributes.kv("issuer", _permit.issuer);
+        attributes = attributes.kv("name", _permit.name);
+        attributes = attributes.kv("holder", ownerOf(_permit.id));
+        attributes = attributes.kv("createdAt", _permit.createdAt);
+        attributes = attributes.kv("validityDur", _permit.validityDur);
+        attributes = attributes.kv("expiresAt", _permit.expiresAt);
+        attributes = attributes.kv("fineGrained", _permit.fineGrained);
+        attributes = attributes.kv("revoked", _permit.revoked);
+        attributes = attributes.kv(
+            "contracts",
+            permitContracts[_permitId].values()
+        );
+        attributes = attributes.kv(
+            "categories",
+            permitProjectIds[_permitId].values()
+        );
+        attributes = attributes.end();
+
+        return
+            JsonBuilder
+                .obj()
+                .kv("name", symbol())
+                .kv("description", name())
+                .kv("attributes", attributes, false)
+                .end()
+                .toBase64();
+    }
+
+    function _bytes32ArrToStringArr(
+        bytes32[] memory values
+    ) internal pure returns (string[] memory bytes32Strings) {
+        bytes32Strings = new string[](values.length);
+        for (uint256 i = 0; i < values.length; i++) {
+            bytes32Strings[i] = JsonBuilder.bytes32ToString(values[i]);
+        }
+    }
+
+    function getPermitInfo(
+        uint256 _permitId
+    ) external view returns (PermitV2FullInfo memory) {
+        PermitV2Info memory _permit = permitInfo[_permitId];
+        return
+            PermitV2FullInfo({
+                id: _permit.id,
+                issuer: _permit.issuer,
+                name: _permit.name,
+                holder: ownerOf(_permitId),
+                createdAt: _permit.createdAt,
+                validityDur: _permit.validityDur,
+                expiresAt: _permit.expiresAt,
+                fineGrained: _permit.fineGrained,
+                revoked: _permit.revoked,
+                contracts: permitContracts[_permitId].values(),
+                projectIds: _bytes32ArrToStringArr(
+                    permitProjectIds[_permitId].values()
+                )
+            });
+    }
+}


### PR DESCRIPTION
## Discussion - PermitV2
[SPEC](https://docs.google.com/document/d/17ZD1zq3CuCWKIc5Zqq91ywC3dd0GLhck6lJOy7mGNGU/edit#heading=h.5wf8re5w1jju)

This PR is for discussing the draft of a PermitV2 spec solution. The main contracts are `PermitV2.sol` and `PermissionedV2.sol`.

The goal of PermitV2 is to improve the user permission & decryption flow. Currently each contract requires its own permit to be generated and signed, which hurts the UX of any dapps that use data from multiple contracts, ex: token portfolio. 

This PermitV2s implementation uses NFTs as Permits, which are minted and held in the user's wallet. These PermitNFTs can be thought of as Github Personal Access Tokens. Minting NFTs will be done through a "Permits" page that is built by the Fhenix team (intended to be included in the DeFi Portal)

### PermitV2 benefits:

- Multi Contract Permits: Use a single permit for multiple contracts instead of an individual permit for each contract. Users will not have to sign a fresh signature for every contract that they interact with, improving user flow.
- Expiration: Permits expire after a user determined duration (fails safe). This could be anywhere from an hour to a year. If a permit expires, it can be "renewed" to extend its validity from the current time.
- Shareable: Users can allow others to see their confidential data (auditors / smart contracts) by minting and sending a PermitNFT with the 2nd user.
- Revocable: Permits can be revoked to prevent bad actors that have gained access. Revoked permits are immediately unavailable. Permits that have already been shared can still be revoked.
- Non-local: Permits shouldn't be usable if they are stolen from a users localstorage
- Granularity
   - Fine Grained - The PermitV2 is valid for a whitelist of contracts determined by the user (users will add contracts to this list over time - see below). These contracts can be added / removed at any time
    - Coarse Grained - The PermitV2 is given a list of projects ("FHERC20" / "Curve" / "UniswapV4") that can be accessed with this permit. Contracts that implement PermissionedV2 are created with a projectId. Permits that have whitelisted that project will then be able to interact with and read from all the required project contracts. Projects are encouraged to use the same projectId across all their contracts, so that users can "approve" the project and immediately be able to interact with the full project functionality. "FHERC20" is added as a project to ensure that all FHERC20 contracts can be read without approving many projects.
   

### User Flow:

When interacting with a dApp, users should be prompted to select the PermitV2 that they want to use. This should be done through a dropdown similar to the "connect" button. The Fhenix team will have to build a scaffold of this component so that it is easy for teams and engineers to integrate. Once the permit is selected, the user will sign a tx to create a permission for that permit which will be used to read confidential data.

If a user is using a fine grained permit (only specific contracts are allowed), then that user will have to add each contract they want to interact with to their permit. This can happen over time, similarly to how users approve contracts to use their tokens.


User Flow Demo - Creating a PermitNFT & Using a PermitNFT

https://github.com/user-attachments/assets/9ff88f6b-d336-48a5-91b3-9ae076f54b41

### Integration Example

! Notice below that in `getCounterPermitSealed` the counter value is fetched for `permission.issuer`. This ensures that the **holder** of the PermitNFT, can see the data of the **minter** of the PermitNFT. This is key to the shareability of the PermitV2.

```solidity
contract Counter is PermissionedV2 {
	mapping(address => euint32) private userCounter;

	constructor() PermissionedV2("COUNTER") {}

	function add(inEuint32 calldata encryptedValue) public {
		euint32 value = FHE.asEuint32(encryptedValue);
		userCounter[msg.sender] = userCounter[msg.sender] + value;
	}

	function getCounterPermitSealed(
		PermissionV2 memory permission
	) public view withPermission(permission) returns (string memory) {
		return userCounter[permission.issuer].seal(permission.publicKey);
	}
}
```

The user would have to approve the project "COUNTER" to read the data from `getCounterPermitSealed`



### `PermitV2.sol` [link](./contracts/PermitV2.sol)

The primary contract that handles the PermitV2 NFTs (minting / updating / renewing / revoking), as well as permission validation. This contract follows the standard NFT paradigm, and users will be able to see their PermitV2s in their metamask or other wallets.

#### Permit functionality

- `createNewPermit` - create a new PermitV2 with options
- `renewPermit` - renews the permit for the validity duration
- `revokePermit` - permanently disables this permit from being used
- `updateProjectIds` - add / remove permitted projectIds from this permit
- `updateContracts` - add / remove permitted contracts from this permit

#### Permission functionality

- `checkPermitSatisfies` - called by `PermissionedV2.sol`, allows dApps to quickly check whether the user's selected PermitNFT will satisfy this contract (checks against contract address / projectId)
- `validatePermission` - called by `PermissionedV2.sol`
  - checks that the permit is active (not expired, not revoked)
  - checks that the tx msg.sender matches the signer of the permission
  - checks that the permit being used is held by the signer
  - checks that the permit issuer matches the permitIssuer of the permission (this value is used to determine what data to return to the user - see Counter.sol example)
  - checks that the contract of the tx is permitted (if permit is fine grained)
  - checks that the category of the tx is permitted (if permit is coarse grained)

#### View

- `tokenURI` - encodes and returns the base64 permit metadata (useful for displaying the PermitV2 as an NFT)
- `getPermitInfo` - returns the permit info as a struct

### `PermissionedV2.sol` [link](./contracts/PermissionedV2.sol)

Thin wrapper around the validation functions of `PermitV2.sol`. Currently the PermitV2 contract address has to be passed in through the constructor, however after the PermitV2 contract is deployed it can be hard coded into the contract.

I have removed `onlyPermitted` / `onlyPermittedBetween` because I think their use cases have been solved by the ability to share permits between users.

## Open Questions

- How do we handle contracts that are using the old permit / permission system
- Better name than permit (which is already associated with gasless token approvals)
- What would the upgrade scheme look like if a bug was found or feature requested
- LocalStorage / SessionStorage for the signed permission
- Does this introduce too much overhead for a user that wants to interact with Fhenix?
- Gas costs for deploying / updating a PermitV2
- Should revoking a permit be a permanent step, or should we allow users to undo this

## Requirements for a mature and integrated release

0. Finalize contracts, add inline docs, add events.
1. Deploy `PermitV2.sol` and update `fhenix-contracts` `PermissionedV2.sol` with the deployed `PermitV2` contract address.
2. Implement a permit management frontend that allows users to create and manage permits.
3. Add a hardhat / foundry precompile that inserts the PermitV2 contract at the correct address for testing
4. Update `fhenixjs` to use PermitV2s. This will need updating in permit generation and unsealing sealed outputs. Include the PermitV2 and PermissionedV2 abi's in fhenixjs so that users can interact with them easily.
5. Write documentation on how to use and integrate PermitV2s for engineers
6. Write documentation on the user flow expectation that Fhenix users can expect when using a Fhenix & PermitV2 enabled dApp