### PR TITLE
Typed sealed outputs

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,0 @@
-{
-	"solidity.remappings": ["@openzeppelin/=node_modules/@openzeppelin/"],
-	"solidity.packageDefaultDependenciesDirectory": ["node_modules", "lib"],
-	"solidity.linter": "",
-	"solidity.formatter": "none"
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+	"solidity.remappings": ["@openzeppelin/=node_modules/@openzeppelin/"],
+	"solidity.packageDefaultDependenciesDirectory": ["node_modules", "lib"],
+	"solidity.linter": "",
+	"solidity.formatter": "none"
+}

--- a/contracts/FHE.sol
+++ b/contracts/FHE.sol
@@ -432,7 +432,7 @@ library FHE {
     /// @param value Ciphertext to decrypt and seal
     /// @param publicKey Public Key that will receive the sealed plaintext
     /// @return SealedBool({ data: Plaintext input, sealed for the owner of `publicKey`, utype: Common.EBOOL_TFHE })
-    function sealoutputtyped(ebool value, bytes32 publicKey) internal pure returns (SealedBool memory) {
+    function sealoutputTyped(ebool value, bytes32 publicKey) internal pure returns (SealedBool memory) {
         return SealedBool({ data: sealoutput(value, publicKey), utype: Common.EBOOL_TFHE });
     }
     /// @notice performs the sealoutput function on a euint8 ciphertext. This operation returns the plaintext value, sealed for the public key provided 
@@ -440,7 +440,7 @@ library FHE {
     /// @param value Ciphertext to decrypt and seal
     /// @param publicKey Public Key that will receive the sealed plaintext
     /// @return SealedUint({ data: Plaintext input, sealed for the owner of `publicKey`, utype: Common.EUINT8_TFHE })
-    function sealoutputtyped(euint8 value, bytes32 publicKey) internal pure returns (SealedUint memory) {
+    function sealoutputTyped(euint8 value, bytes32 publicKey) internal pure returns (SealedUint memory) {
         return SealedUint({ data: sealoutput(value, publicKey), utype: Common.EUINT8_TFHE });
     }
     /// @notice performs the sealoutput function on a euint16 ciphertext. This operation returns the plaintext value, sealed for the public key provided 
@@ -448,7 +448,7 @@ library FHE {
     /// @param value Ciphertext to decrypt and seal
     /// @param publicKey Public Key that will receive the sealed plaintext
     /// @return SealedUint({ data: Plaintext input, sealed for the owner of `publicKey`, utype: Common.EUINT16_TFHE })
-    function sealoutputtyped(euint16 value, bytes32 publicKey) internal pure returns (SealedUint memory) {
+    function sealoutputTyped(euint16 value, bytes32 publicKey) internal pure returns (SealedUint memory) {
         return SealedUint({ data: sealoutput(value, publicKey), utype: Common.EUINT16_TFHE });
     }
     /// @notice performs the sealoutput function on a euint32 ciphertext. This operation returns the plaintext value, sealed for the public key provided 
@@ -456,7 +456,7 @@ library FHE {
     /// @param value Ciphertext to decrypt and seal
     /// @param publicKey Public Key that will receive the sealed plaintext
     /// @return SealedUint({ data: Plaintext input, sealed for the owner of `publicKey`, utype: Common.EUINT32_TFHE })
-    function sealoutputtyped(euint32 value, bytes32 publicKey) internal pure returns (SealedUint memory) {
+    function sealoutputTyped(euint32 value, bytes32 publicKey) internal pure returns (SealedUint memory) {
         return SealedUint({ data: sealoutput(value, publicKey), utype: Common.EUINT32_TFHE });
     }
     /// @notice performs the sealoutput function on a euint64 ciphertext. This operation returns the plaintext value, sealed for the public key provided 
@@ -464,7 +464,7 @@ library FHE {
     /// @param value Ciphertext to decrypt and seal
     /// @param publicKey Public Key that will receive the sealed plaintext
     /// @return SealedUint({ data: Plaintext input, sealed for the owner of `publicKey`, utype: Common.EUINT64_TFHE })
-    function sealoutputtyped(euint64 value, bytes32 publicKey) internal pure returns (SealedUint memory) {
+    function sealoutputTyped(euint64 value, bytes32 publicKey) internal pure returns (SealedUint memory) {
         return SealedUint({ data: sealoutput(value, publicKey), utype: Common.EUINT64_TFHE });
     }
     /// @notice performs the sealoutput function on a euint128 ciphertext. This operation returns the plaintext value, sealed for the public key provided 
@@ -472,7 +472,7 @@ library FHE {
     /// @param value Ciphertext to decrypt and seal
     /// @param publicKey Public Key that will receive the sealed plaintext
     /// @return SealedUint({ data: Plaintext input, sealed for the owner of `publicKey`, utype: Common.EUINT128_TFHE })
-    function sealoutputtyped(euint128 value, bytes32 publicKey) internal pure returns (SealedUint memory) {
+    function sealoutputTyped(euint128 value, bytes32 publicKey) internal pure returns (SealedUint memory) {
         return SealedUint({ data: sealoutput(value, publicKey), utype: Common.EUINT128_TFHE });
     }
     /// @notice performs the sealoutput function on a euint256 ciphertext. This operation returns the plaintext value, sealed for the public key provided 
@@ -480,7 +480,7 @@ library FHE {
     /// @param value Ciphertext to decrypt and seal
     /// @param publicKey Public Key that will receive the sealed plaintext
     /// @return SealedUint({ data: Plaintext input, sealed for the owner of `publicKey`, utype: Common.EUINT256_TFHE })
-    function sealoutputtyped(euint256 value, bytes32 publicKey) internal pure returns (SealedUint memory) {
+    function sealoutputTyped(euint256 value, bytes32 publicKey) internal pure returns (SealedUint memory) {
         return SealedUint({ data: sealoutput(value, publicKey), utype: Common.EUINT256_TFHE });
     }
     /// @notice performs the sealoutput function on a eaddress ciphertext. This operation returns the plaintext value, sealed for the public key provided 
@@ -488,7 +488,7 @@ library FHE {
     /// @param value Ciphertext to decrypt and seal
     /// @param publicKey Public Key that will receive the sealed plaintext
     /// @return SealedAddress({ data: Plaintext input, sealed for the owner of `publicKey`, utype: Common.EADDRESS_TFHE })
-    function sealoutputtyped(eaddress value, bytes32 publicKey) internal pure returns (SealedAddress memory) {
+    function sealoutputTyped(eaddress value, bytes32 publicKey) internal pure returns (SealedAddress memory) {
         return SealedAddress({ data: sealoutput(value, publicKey), utype: Common.EADDRESS_TFHE });
     }
     /// @notice Performs the decrypt operation on a ciphertext
@@ -3742,7 +3742,7 @@ library BindingsEbool {
         return FHE.sealoutput(value, publicKey);
     }
     function sealTyped(ebool value, bytes32 publicKey) internal pure returns (SealedBool memory) {
-        return FHE.sealoutputtyped(value, publicKey);
+        return FHE.sealoutputTyped(value, publicKey);
     }
     function decrypt(ebool value) internal pure returns (bool) {
         return FHE.decrypt(value);
@@ -3971,8 +3971,8 @@ library BindingsEuint8 {
     function seal(euint8 value, bytes32 publicKey) internal pure returns (string memory) {
         return FHE.sealoutput(value, publicKey);
     }
-    function sealtyped(euint8 value, bytes32 publicKey) internal pure returns (SealedUint memory) {
-        return FHE.sealoutputtyped(value, publicKey);
+    function sealTyped(euint8 value, bytes32 publicKey) internal pure returns (SealedUint memory) {
+        return FHE.sealoutputTyped(value, publicKey);
     }
     function decrypt(euint8 value) internal pure returns (uint8) {
         return FHE.decrypt(value);
@@ -4201,8 +4201,8 @@ library BindingsEuint16 {
     function seal(euint16 value, bytes32 publicKey) internal pure returns (string memory) {
         return FHE.sealoutput(value, publicKey);
     }
-    function sealtyped(euint16 value, bytes32 publicKey) internal pure returns (SealedUint memory) {
-        return FHE.sealoutputtyped(value, publicKey);
+    function sealTyped(euint16 value, bytes32 publicKey) internal pure returns (SealedUint memory) {
+        return FHE.sealoutputTyped(value, publicKey);
     }
     function decrypt(euint16 value) internal pure returns (uint16) {
         return FHE.decrypt(value);
@@ -4431,8 +4431,8 @@ library BindingsEuint32 {
     function seal(euint32 value, bytes32 publicKey) internal pure returns (string memory) {
         return FHE.sealoutput(value, publicKey);
     }
-    function sealtyped(euint32 value, bytes32 publicKey) internal pure returns (SealedUint memory) {
-        return FHE.sealoutputtyped(value, publicKey);
+    function sealTyped(euint32 value, bytes32 publicKey) internal pure returns (SealedUint memory) {
+        return FHE.sealoutputTyped(value, publicKey);
     }
     function decrypt(euint32 value) internal pure returns (uint32) {
         return FHE.decrypt(value);
@@ -4643,8 +4643,8 @@ library BindingsEuint64 {
     function seal(euint64 value, bytes32 publicKey) internal pure returns (string memory) {
         return FHE.sealoutput(value, publicKey);
     }
-    function sealtyped(euint64 value, bytes32 publicKey) internal pure returns (SealedUint memory) {
-        return FHE.sealoutputtyped(value, publicKey);
+    function sealTyped(euint64 value, bytes32 publicKey) internal pure returns (SealedUint memory) {
+        return FHE.sealoutputTyped(value, publicKey);
     }
     function decrypt(euint64 value) internal pure returns (uint64) {
         return FHE.decrypt(value);
@@ -4838,8 +4838,8 @@ library BindingsEuint128 {
     function seal(euint128 value, bytes32 publicKey) internal pure returns (string memory) {
         return FHE.sealoutput(value, publicKey);
     }
-    function sealtyped(euint128 value, bytes32 publicKey) internal pure returns (SealedUint memory) {
-        return FHE.sealoutputtyped(value, publicKey);
+    function sealTyped(euint128 value, bytes32 publicKey) internal pure returns (SealedUint memory) {
+        return FHE.sealoutputTyped(value, publicKey);
     }
     function decrypt(euint128 value) internal pure returns (uint128) {
         return FHE.decrypt(value);
@@ -4893,8 +4893,8 @@ library BindingsEuint256 {
     function seal(euint256 value, bytes32 publicKey) internal pure returns (string memory) {
         return FHE.sealoutput(value, publicKey);
     }
-    function sealtyped(euint256 value, bytes32 publicKey) internal pure returns (SealedUint memory) {
-        return FHE.sealoutputtyped(value, publicKey);
+    function sealTyped(euint256 value, bytes32 publicKey) internal pure returns (SealedUint memory) {
+        return FHE.sealoutputTyped(value, publicKey);
     }
     function decrypt(euint256 value) internal pure returns (uint256) {
         return FHE.decrypt(value);
@@ -4948,8 +4948,8 @@ library BindingsEaddress {
     function seal(eaddress value, bytes32 publicKey) internal pure returns (string memory) {
         return FHE.sealoutput(value, publicKey);
     }
-    function sealtyped(eaddress value, bytes32 publicKey) internal pure returns (SealedAddress memory) {
-        return FHE.sealoutputtyped(value, publicKey);
+    function sealTyped(eaddress value, bytes32 publicKey) internal pure returns (SealedAddress memory) {
+        return FHE.sealoutputTyped(value, publicKey);
     }
     function decrypt(eaddress value) internal pure returns (address) {
         return FHE.decrypt(value);

--- a/contracts/FHE.sol
+++ b/contracts/FHE.sol
@@ -51,16 +51,26 @@ struct SealedArray {
     bytes[] data;
 }
 
+/// @dev Utility structure providing clients with type context of a sealed output string.
+/// Returned from `FHE.sealoutputTyped` and `sealTyped` within the bindings.
+/// `utype` representing Bool is 13. See `FHE.sol` for more.
 struct SealedBool {
 	string data;
 	uint8 utype;
 }
 
+/// @dev Utility structure providing clients with type context of a sealed output string.
+/// Returned from `FHE.sealoutputTyped` and `sealTyped` within the bindings.
+/// `utype` representing Uints is 0-5. See `FHE.sol` for more.
+/// `utype` map: {uint8: 0} {uint16: 1} {uint32: 1} {uint64: 3} {uint128: 4} {uint256: 5}.
 struct SealedUint {
 	string data;
 	uint8 utype;
 }
 
+/// @dev Utility structure providing clients with type context of a sealed output string.
+/// Returned from `FHE.sealoutputTyped` and `sealTyped` within the bindings.
+/// `utype` representing Address is 12. See `FHE.sol` for more.
 struct SealedAddress {
 	string data;
 	uint8 utype;

--- a/contracts/FHE.sol
+++ b/contracts/FHE.sol
@@ -48,7 +48,22 @@ struct inEaddress {
 }
 
 struct SealedArray {
-  bytes[] data;
+    bytes[] data;
+}
+
+struct SealedBool {
+	string data;
+	uint8 utype;
+}
+
+struct SealedUint {
+	string data;
+	uint8 utype;
+}
+
+struct SealedAddress {
+	string data;
+	uint8 utype;
 }
 
 library Common {
@@ -411,6 +426,70 @@ library FHE {
         uint256 unwrapped = eaddress.unwrap(value);
 
         return Impl.sealoutput(Common.EADDRESS_TFHE, unwrapped, publicKey);
+    }
+    /// @notice performs the sealoutput function on a ebool ciphertext. This operation returns the plaintext value, sealed for the public key provided 
+    /// @dev Pure in this function is marked as a hack/workaround - note that this function is NOT pure as fetches of ciphertexts require state access
+    /// @param value Ciphertext to decrypt and seal
+    /// @param publicKey Public Key that will receive the sealed plaintext
+    /// @return SealedBool({ data: Plaintext input, sealed for the owner of `publicKey`, utype: Common.EBOOL_TFHE })
+    function sealoutputtyped(ebool value, bytes32 publicKey) internal pure returns (SealedBool memory) {
+        return SealedBool({ data: sealoutput(value, publicKey), utype: Common.EBOOL_TFHE });
+    }
+    /// @notice performs the sealoutput function on a euint8 ciphertext. This operation returns the plaintext value, sealed for the public key provided 
+    /// @dev Pure in this function is marked as a hack/workaround - note that this function is NOT pure as fetches of ciphertexts require state access
+    /// @param value Ciphertext to decrypt and seal
+    /// @param publicKey Public Key that will receive the sealed plaintext
+    /// @return SealedUint({ data: Plaintext input, sealed for the owner of `publicKey`, utype: Common.EUINT8_TFHE })
+    function sealoutputtyped(euint8 value, bytes32 publicKey) internal pure returns (SealedUint memory) {
+        return SealedUint({ data: sealoutput(value, publicKey), utype: Common.EUINT8_TFHE });
+    }
+    /// @notice performs the sealoutput function on a euint16 ciphertext. This operation returns the plaintext value, sealed for the public key provided 
+    /// @dev Pure in this function is marked as a hack/workaround - note that this function is NOT pure as fetches of ciphertexts require state access
+    /// @param value Ciphertext to decrypt and seal
+    /// @param publicKey Public Key that will receive the sealed plaintext
+    /// @return SealedUint({ data: Plaintext input, sealed for the owner of `publicKey`, utype: Common.EUINT16_TFHE })
+    function sealoutputtyped(euint16 value, bytes32 publicKey) internal pure returns (SealedUint memory) {
+        return SealedUint({ data: sealoutput(value, publicKey), utype: Common.EUINT16_TFHE });
+    }
+    /// @notice performs the sealoutput function on a euint32 ciphertext. This operation returns the plaintext value, sealed for the public key provided 
+    /// @dev Pure in this function is marked as a hack/workaround - note that this function is NOT pure as fetches of ciphertexts require state access
+    /// @param value Ciphertext to decrypt and seal
+    /// @param publicKey Public Key that will receive the sealed plaintext
+    /// @return SealedUint({ data: Plaintext input, sealed for the owner of `publicKey`, utype: Common.EUINT32_TFHE })
+    function sealoutputtyped(euint32 value, bytes32 publicKey) internal pure returns (SealedUint memory) {
+        return SealedUint({ data: sealoutput(value, publicKey), utype: Common.EUINT32_TFHE });
+    }
+    /// @notice performs the sealoutput function on a euint64 ciphertext. This operation returns the plaintext value, sealed for the public key provided 
+    /// @dev Pure in this function is marked as a hack/workaround - note that this function is NOT pure as fetches of ciphertexts require state access
+    /// @param value Ciphertext to decrypt and seal
+    /// @param publicKey Public Key that will receive the sealed plaintext
+    /// @return SealedUint({ data: Plaintext input, sealed for the owner of `publicKey`, utype: Common.EUINT64_TFHE })
+    function sealoutputtyped(euint64 value, bytes32 publicKey) internal pure returns (SealedUint memory) {
+        return SealedUint({ data: sealoutput(value, publicKey), utype: Common.EUINT64_TFHE });
+    }
+    /// @notice performs the sealoutput function on a euint128 ciphertext. This operation returns the plaintext value, sealed for the public key provided 
+    /// @dev Pure in this function is marked as a hack/workaround - note that this function is NOT pure as fetches of ciphertexts require state access
+    /// @param value Ciphertext to decrypt and seal
+    /// @param publicKey Public Key that will receive the sealed plaintext
+    /// @return SealedUint({ data: Plaintext input, sealed for the owner of `publicKey`, utype: Common.EUINT128_TFHE })
+    function sealoutputtyped(euint128 value, bytes32 publicKey) internal pure returns (SealedUint memory) {
+        return SealedUint({ data: sealoutput(value, publicKey), utype: Common.EUINT128_TFHE });
+    }
+    /// @notice performs the sealoutput function on a euint256 ciphertext. This operation returns the plaintext value, sealed for the public key provided 
+    /// @dev Pure in this function is marked as a hack/workaround - note that this function is NOT pure as fetches of ciphertexts require state access
+    /// @param value Ciphertext to decrypt and seal
+    /// @param publicKey Public Key that will receive the sealed plaintext
+    /// @return SealedUint({ data: Plaintext input, sealed for the owner of `publicKey`, utype: Common.EUINT256_TFHE })
+    function sealoutputtyped(euint256 value, bytes32 publicKey) internal pure returns (SealedUint memory) {
+        return SealedUint({ data: sealoutput(value, publicKey), utype: Common.EUINT256_TFHE });
+    }
+    /// @notice performs the sealoutput function on a eaddress ciphertext. This operation returns the plaintext value, sealed for the public key provided 
+    /// @dev Pure in this function is marked as a hack/workaround - note that this function is NOT pure as fetches of ciphertexts require state access
+    /// @param value Ciphertext to decrypt and seal
+    /// @param publicKey Public Key that will receive the sealed plaintext
+    /// @return SealedAddress({ data: Plaintext input, sealed for the owner of `publicKey`, utype: Common.EADDRESS_TFHE })
+    function sealoutputtyped(eaddress value, bytes32 publicKey) internal pure returns (SealedAddress memory) {
+        return SealedAddress({ data: sealoutput(value, publicKey), utype: Common.EADDRESS_TFHE });
     }
     /// @notice Performs the decrypt operation on a ciphertext
     /// @dev Verifies that the input value matches a valid ciphertext. Pure in this function is marked as a hack/workaround - note that this function is NOT pure as fetches of ciphertexts require state access
@@ -3662,6 +3741,9 @@ library BindingsEbool {
     function seal(ebool value, bytes32 publicKey) internal pure returns (string memory) {
         return FHE.sealoutput(value, publicKey);
     }
+    function sealTyped(ebool value, bytes32 publicKey) internal pure returns (SealedBool memory) {
+        return FHE.sealoutputtyped(value, publicKey);
+    }
     function decrypt(ebool value) internal pure returns (bool) {
         return FHE.decrypt(value);
     }
@@ -3888,6 +3970,9 @@ library BindingsEuint8 {
     }
     function seal(euint8 value, bytes32 publicKey) internal pure returns (string memory) {
         return FHE.sealoutput(value, publicKey);
+    }
+    function sealtyped(euint8 value, bytes32 publicKey) internal pure returns (SealedUint memory) {
+        return FHE.sealoutputtyped(value, publicKey);
     }
     function decrypt(euint8 value) internal pure returns (uint8) {
         return FHE.decrypt(value);
@@ -4116,6 +4201,9 @@ library BindingsEuint16 {
     function seal(euint16 value, bytes32 publicKey) internal pure returns (string memory) {
         return FHE.sealoutput(value, publicKey);
     }
+    function sealtyped(euint16 value, bytes32 publicKey) internal pure returns (SealedUint memory) {
+        return FHE.sealoutputtyped(value, publicKey);
+    }
     function decrypt(euint16 value) internal pure returns (uint16) {
         return FHE.decrypt(value);
     }
@@ -4343,6 +4431,9 @@ library BindingsEuint32 {
     function seal(euint32 value, bytes32 publicKey) internal pure returns (string memory) {
         return FHE.sealoutput(value, publicKey);
     }
+    function sealtyped(euint32 value, bytes32 publicKey) internal pure returns (SealedUint memory) {
+        return FHE.sealoutputtyped(value, publicKey);
+    }
     function decrypt(euint32 value) internal pure returns (uint32) {
         return FHE.decrypt(value);
     }
@@ -4552,6 +4643,9 @@ library BindingsEuint64 {
     function seal(euint64 value, bytes32 publicKey) internal pure returns (string memory) {
         return FHE.sealoutput(value, publicKey);
     }
+    function sealtyped(euint64 value, bytes32 publicKey) internal pure returns (SealedUint memory) {
+        return FHE.sealoutputtyped(value, publicKey);
+    }
     function decrypt(euint64 value) internal pure returns (uint64) {
         return FHE.decrypt(value);
     }
@@ -4744,6 +4838,9 @@ library BindingsEuint128 {
     function seal(euint128 value, bytes32 publicKey) internal pure returns (string memory) {
         return FHE.sealoutput(value, publicKey);
     }
+    function sealtyped(euint128 value, bytes32 publicKey) internal pure returns (SealedUint memory) {
+        return FHE.sealoutputtyped(value, publicKey);
+    }
     function decrypt(euint128 value) internal pure returns (uint128) {
         return FHE.decrypt(value);
     }
@@ -4796,6 +4893,9 @@ library BindingsEuint256 {
     function seal(euint256 value, bytes32 publicKey) internal pure returns (string memory) {
         return FHE.sealoutput(value, publicKey);
     }
+    function sealtyped(euint256 value, bytes32 publicKey) internal pure returns (SealedUint memory) {
+        return FHE.sealoutputtyped(value, publicKey);
+    }
     function decrypt(euint256 value) internal pure returns (uint256) {
         return FHE.decrypt(value);
     }
@@ -4847,6 +4947,9 @@ library BindingsEaddress {
     }
     function seal(eaddress value, bytes32 publicKey) internal pure returns (string memory) {
         return FHE.sealoutput(value, publicKey);
+    }
+    function sealtyped(eaddress value, bytes32 publicKey) internal pure returns (SealedAddress memory) {
+        return FHE.sealoutputtyped(value, publicKey);
     }
     function decrypt(eaddress value) internal pure returns (address) {
         return FHE.decrypt(value);

--- a/contracts/FHE.sol
+++ b/contracts/FHE.sol
@@ -62,7 +62,7 @@ struct SealedBool {
 /// @dev Utility structure providing clients with type context of a sealed output string.
 /// Returned from `FHE.sealoutputTyped` and `sealTyped` within the bindings.
 /// `utype` representing Uints is 0-5. See `FHE.sol` for more.
-/// `utype` map: {uint8: 0} {uint16: 1} {uint32: 1} {uint64: 3} {uint128: 4} {uint256: 5}.
+/// `utype` map: {uint8: 0} {uint16: 1} {uint32: 2} {uint64: 3} {uint128: 4} {uint256: 5}.
 struct SealedUint {
 	string data;
 	uint8 utype;

--- a/contracts/test/TypedSealedOutputsTest.sol
+++ b/contracts/test/TypedSealedOutputsTest.sol
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.13 <0.9.0;
+
+import {FHE, BindingsEbool, BindingsEuint8, SealedBool, SealedUint, SealedAddress, ebool, euint8, euint16, euint32, euint64, euint128, euint256, eaddress} from "../FHE.sol";
+import {PermissionedV2, PermissionV2} from "../access/PermissionedV2.sol";
+
+contract TypedSealedOutputsTest is PermissionedV2 {
+    using BindingsEuint8 for euint8;
+
+    constructor() PermissionedV2("TEST") {}
+
+    function getSealedEBool(PermissionV2 memory permission, bool value) public view withPermission(permission) returns (SealedBool memory, SealedBool memory) {
+        return (
+            FHE.sealoutputTyped(FHE.asEbool(value), permission.sealingKey),
+            FHE.asEbool(value).sealTyped(permission.sealingKey)
+        );
+    }
+
+    function getSealedEUint8(PermissionV2 memory permission, uint8 value) public view withPermission(permission) returns (SealedUint memory, SealedUint memory) {
+        return (
+            FHE.sealoutputTyped(FHE.asEuint8(value), permission.sealingKey),
+            FHE.asEuint8(value).sealTyped(permission.sealingKey)
+        );
+    }
+
+    function getSealedEUint16(PermissionV2 memory permission, uint16 value) public view withPermission(permission) returns (SealedUint memory, SealedUint memory) {
+        return (
+            FHE.sealoutputTyped(FHE.asEuint16(value), permission.sealingKey),
+            FHE.asEuint16(value).sealTyped(permission.sealingKey)
+        );
+    }
+
+    function getSealedEUint32(PermissionV2 memory permission, uint32 value) public view withPermission(permission) returns (SealedUint memory, SealedUint memory) {
+        return (
+            FHE.sealoutputTyped(FHE.asEuint32(value), permission.sealingKey),
+            FHE.asEuint32(value).sealTyped(permission.sealingKey)
+        );
+    }
+
+    function getSealedEUint64(PermissionV2 memory permission, uint64 value) public view withPermission(permission) returns (SealedUint memory, SealedUint memory) {
+        return (
+            FHE.sealoutputTyped(FHE.asEuint64(value), permission.sealingKey),
+            FHE.asEuint64(value).sealTyped(permission.sealingKey)
+        );
+    }
+
+
+
+    function getSealedEUint128(PermissionV2 memory permission, uint128 value) public view withPermission(permission) returns (SealedUint memory, SealedUint memory) {
+        return (
+            FHE.sealoutputTyped(FHE.asEuint128(value), permission.sealingKey),
+            FHE.asEuint128(value).sealTyped(permission.sealingKey)
+        );
+    }
+
+
+
+    function getSealedEUint256(PermissionV2 memory permission, uint256 value) public view withPermission(permission) returns (SealedUint memory, SealedUint memory) {
+        return (
+            FHE.sealoutputTyped(FHE.asEuint256(value), permission.sealingKey),
+            FHE.asEuint256(value).sealTyped(permission.sealingKey)
+        );
+    }
+
+    function getSealedEAddress(PermissionV2 memory permission, address value) public view withPermission(permission) returns (SealedAddress memory, SealedAddress memory) {
+        return (
+            FHE.sealoutputTyped(FHE.asEaddress(value), permission.sealingKey),
+            FHE.asEaddress(value).sealTyped(permission.sealingKey)
+        );
+    }
+}

--- a/test/fhe/typedSealedOutputs.ts
+++ b/test/fhe/typedSealedOutputs.ts
@@ -1,0 +1,108 @@
+import { expect } from 'chai'
+import { ethers } from 'hardhat'
+
+import { getTokensFromFaucet } from '../permitV2/chain-utils'
+import { generatePermitV2, extractPermissionV2 } from '../permitV2/permit-v2-utils'
+import { TypedSealedOutputsTest__factory } from '../../types'
+import { getAddress } from 'ethers'
+
+const EUINT8_TFHE = 0
+const EUINT16_TFHE = 1
+const EUINT32_TFHE = 2
+const EUINT64_TFHE = 3
+const EUINT128_TFHE = 4
+const EUINT256_TFHE = 5
+const EADDRESS_TFHE = 12
+const EBOOL_TFHE = 13
+
+const EUINT_TFHE = {
+	8: EUINT8_TFHE,
+	16: EUINT16_TFHE,
+	32: EUINT32_TFHE,
+	64: EUINT64_TFHE,
+	128: EUINT128_TFHE,
+	256: EUINT256_TFHE,
+} as const
+
+describe('TypedSealedOutputs', function () {
+	async function typedSealedOutputsFixture() {
+		const signer = (await ethers.getSigners())[0]
+		await getTokensFromFaucet(signer.address)
+
+		const typedSealedOutputsFactory = (await ethers.getContractFactory('TypedSealedOutputsTest')) as TypedSealedOutputsTest__factory
+		const typedSealedOutputs = await typedSealedOutputsFactory.deploy()
+		await typedSealedOutputs.waitForDeployment()
+		const typedSealedOutputsAddress = await typedSealedOutputs.getAddress()
+
+		// Signer permit and permission
+		const permit = await generatePermitV2(
+			{
+				issuer: signer.address,
+				projects: ['TEST'],
+			},
+			ethers.provider,
+			signer
+		)
+		const permission = extractPermissionV2(permit)
+
+		return {
+			signer,
+			typedSealedOutputs,
+			typedSealedOutputsAddress,
+			permit,
+			permission,
+		}
+	}
+
+	it('SealedBool', async () => {
+		const { typedSealedOutputs, permit, permission } = await typedSealedOutputsFixture()
+		const value = true
+
+		const [fheOutput, bindingsOutput] = await typedSealedOutputs.getSealedEBool(permission, value)
+
+		// NOTE: Unsealing a sealed bool returns a BigInt
+		// This function converts a bigint into a boolean
+		const bnToBoolean = (bn: BigInt) => Boolean(bn).valueOf()
+
+		expect(fheOutput.utype).to.eq(EBOOL_TFHE, 'sealed bool utype (fhe)')
+		expect(bnToBoolean(permit.sealingPair.unseal(fheOutput.data))).to.eq(value, 'unsealed bool match (fhe)')
+
+		expect(bindingsOutput.utype).to.eq(EBOOL_TFHE, 'sealed bool utype (bindings)')
+		expect(bnToBoolean(permit.sealingPair.unseal(bindingsOutput.data))).to.eq(value, 'unsealed bool match (bindings)')
+	})
+
+	describe('SealedUint', async () => {
+		;([8, 16, 32, 64, 128, 256] as const).map((value) =>
+			it(`euint${value}`, async () => {
+				const { typedSealedOutputs, permit, permission } = await typedSealedOutputsFixture()
+
+				const [fheOutput, bindingsOutput] = await typedSealedOutputs[`getSealedEUint${value}`](permission, value)
+
+				expect(fheOutput.utype).to.eq(EUINT_TFHE[value], `sealed uint${value} utype (fhe)`)
+				expect(permit.sealingPair.unseal(fheOutput.data)).to.eq(value, `unsealed uint${value} match (fhe)`)
+
+				expect(bindingsOutput.utype).to.eq(EUINT_TFHE[value], `sealed uint${value} utype (bindings)`)
+				expect(permit.sealingPair.unseal(bindingsOutput.data)).to.eq(value, `unsealed uint${value} match (bindings)`)
+			})
+		)
+	})
+
+	it('SealedAddress', async () => {
+		const { typedSealedOutputs, permit, permission } = await typedSealedOutputsFixture()
+
+		// Random address
+		const value = '0x1BDB34f2cEA785317903eD9618F5282BD5Be5c75'
+
+		const [fheOutput, bindingsOutput] = await typedSealedOutputs.getSealedEAddress(permission, value)
+
+		// NOTE: Unsealing a sealed address returns a bigint
+		// This function converts a bigint into a checksummed address (dependency:ethers)
+		const bnToAddress = (bn: BigInt) => getAddress(`0x${bn.toString(16).slice(-40)}`)
+
+		expect(fheOutput.utype).to.eq(EADDRESS_TFHE, 'sealed address utype (fhe)')
+		expect(bnToAddress(permit.sealingPair.unseal(fheOutput.data))).to.eq(value, 'unsealed address match (fhe)')
+
+		expect(bindingsOutput.utype).to.eq(EADDRESS_TFHE, 'sealed address utype (bindings)')
+		expect(bnToAddress(permit.sealingPair.unseal(bindingsOutput.data))).to.eq(value, 'unsealed address match (bindings)')
+	})
+})


### PR DESCRIPTION
Introduces typing as on option when sealing return data to match the encrypted input structs. I've introduced it as a non breaking change so existing work will remain working.

Structs:
```solidity
struct SealedBool {
	string data;
	uint8 utype;
}

struct SealedUint {
	string data;
	uint8 utype;
}

struct SealedAddress {
	string data;
	uint8 utype;
}
```

Usage:
```solidity
euint8 encValue;

function getSealedTyped(Permission memory permission) public view returns (SealedUint memory) {
    return encValue.sealtyped(permission.publicKey);
    // or
    return FHE.sealoutputtyped(encValue, permission.publicKey);
}
```

This is very useful in the frontend when building tooling. A user could look at the `utype` to format the output of a function. 

As an example, the frontend tooling I've built up looks at the utype when automatically parsing sealed outputs:

```typescript
  // Function signature:
  // getCounterPermitSealed(Permission calldata permission) public returns (SealedBool, SealedUint)

  // Abi:
  // name: "getCounterPermitSealed",
  // outputs: [
  //   {
  //     components: [...],
  //     internalType: "struct SealedBool",
  //     name: "",
  //     type: "tuple",
  //   },
  //   {
  //     components: [...},
  //     ],
  //     internalType: "struct SealedUint",
  //     name: "",
  //     type: "tuple",
  //   },
  // ],
  // stateMutability: "view",
  // type: "function",

  const { data: counterValue, permitted: counterPermitted } = useFhenixScaffoldReadContract({
    //                ^? const counterValue: readonly [boolean, bigint] | undefined
    contractName: CONTRACT_NAME,
    functionName: "getCounterPermitSealed",
    watch: true,
    args: ["populate-fhenix-permission"],
    // ^? (property) args: readonly ["populate-fhenix-permission" | undefined]
  });
  ```
