### PR TITLE
Fix : Incorrect Mapping Key Definition in FHERC721 Contract

### DIFF
--- a/contracts/experimental/token/FHERC721/FHERC721.sol
+++ b/contracts/experimental/token/FHERC721/FHERC721.sol
@@ -12,7 +12,7 @@ import { IFHERC721 } from "./IFHERC721.sol";
 contract FHERC721 is IFHERC721, Permissioned, ERC721 {
     using Strings for uint256;
 
-    mapping(uint256 tokenId => euint256) private _privateData;
+    mapping(uint256 => euint256) private _privateData;
 
     constructor(
         string memory name,


### PR DESCRIPTION
This PR corrects the definition of the _privateData mapping in the FHERC721 contract. The previous declaration mapping(uint256 tokenId => euint256) was invalid in Solidity. It has been updated to the correct form mapping(uint256 => euint256) to ensure proper functionality.