### PR TITLE
PermissionedV2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ types
 deployments
 .idea
 contracts-exposed
+.vscode
 
 # files
 *.env

--- a/contracts/access/EIP712.sol
+++ b/contracts/access/EIP712.sol
@@ -1,0 +1,175 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts (last updated v5.0.0) (utils/cryptography/EIP712.sol)
+
+pragma solidity ^0.8.20;
+
+import {MessageHashUtils} from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
+import {ShortStrings, ShortString} from "@openzeppelin/contracts/utils/ShortStrings.sol";
+import {IERC5267} from "@openzeppelin/contracts/interfaces/IERC5267.sol";
+
+/**
+ * @dev https://eips.ethereum.org/EIPS/eip-712[EIP 712] is a standard for hashing and signing of typed structured data.
+ *
+ * The encoding scheme specified in the EIP requires a domain separator and a hash of the typed structured data, whose
+ * encoding is very generic and therefore its implementation in Solidity is not feasible, thus this contract
+ * does not implement the encoding itself. Protocols need to implement the type-specific encoding they need in order to
+ * produce the hash of their typed data using a combination of `abi.encode` and `keccak256`.
+ *
+ * This contract implements the EIP 712 domain separator ({_domainSeparatorV4}) that is used as part of the encoding
+ * scheme, and the final step of the encoding to obtain the message digest that is then signed via ECDSA
+ * ({_hashTypedDataV4}).
+ *
+ * The implementation of the domain separator was designed to be as efficient as possible while still properly updating
+ * the chain id to protect against replay attacks on an eventual fork of the chain.
+ *
+ * NOTE: This contract implements the version of the encoding known as "v4", as implemented by the JSON RPC method
+ * https://docs.metamask.io/guide/signing-data.html[`eth_signTypedDataV4` in MetaMask].
+ *
+ * NOTE: In the upgradeable version of this contract, the cached values will correspond to the address, and the domain
+ * separator of the implementation contract. This will cause the {_domainSeparatorV4} function to always rebuild the
+ * separator from the immutable values, which is cheaper than accessing a cached version in cold storage.
+ *
+ * @custom:oz-upgrades-unsafe-allow state-variable-immutable
+ *
+ * NOTE: Fhenix read access Permits are intended to be used in multiple contracts simultaneously, therefor the
+ * `verifyingContract` which is by default address(this) has been replaced with address(0).
+ */
+abstract contract EIP712 is IERC5267 {
+    using ShortStrings for *;
+
+    bytes32 private constant TYPE_HASH =
+        keccak256(
+            "EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"
+        );
+
+    // Cache the domain separator as an immutable value, but also store the chain id that it corresponds to, in order to
+    // invalidate the cached domain separator if the chain id changes.
+    bytes32 private immutable _cachedDomainSeparator;
+    uint256 private immutable _cachedChainId;
+
+    bytes32 private immutable _hashedName;
+    bytes32 private immutable _hashedVersion;
+
+    ShortString private immutable _name;
+    ShortString private immutable _version;
+    string private _nameFallback;
+    string private _versionFallback;
+
+    /**
+     * @dev Initializes the domain separator and parameter caches.
+     *
+     * The meaning of `name` and `version` is specified in
+     * https://eips.ethereum.org/EIPS/eip-712#definition-of-domainseparator[EIP 712]:
+     *
+     * - `name`: the user readable name of the signing domain, i.e. the name of the DApp or the protocol.
+     * - `version`: the current major version of the signing domain.
+     *
+     * NOTE: These parameters cannot be changed except through a xref:learn::upgrading-smart-contracts.adoc[smart
+     * contract upgrade].
+     */
+    constructor(string memory name, string memory version) {
+        _name = name.toShortStringWithFallback(_nameFallback);
+        _version = version.toShortStringWithFallback(_versionFallback);
+        _hashedName = keccak256(bytes(name));
+        _hashedVersion = keccak256(bytes(version));
+
+        _cachedChainId = block.chainid;
+        _cachedDomainSeparator = _buildDomainSeparator();
+    }
+
+    /**
+     * @dev Returns the domain separator for the current chain.
+     */
+    function _domainSeparatorV4() internal view returns (bytes32) {
+        if (block.chainid == _cachedChainId) {
+            return _cachedDomainSeparator;
+        } else {
+            return _buildDomainSeparator();
+        }
+    }
+
+    function _buildDomainSeparator() private view returns (bytes32) {
+        return
+            keccak256(
+                abi.encode(
+                    TYPE_HASH,
+                    _hashedName,
+                    _hashedVersion,
+                    block.chainid,
+                    address(0)
+                )
+            );
+    }
+
+    /**
+     * @dev Given an already https://eips.ethereum.org/EIPS/eip-712#definition-of-hashstruct[hashed struct], this
+     * function returns the hash of the fully encoded EIP712 message for this domain.
+     *
+     * This hash can be used together with {ECDSA-recover} to obtain the signer of a message. For example:
+     *
+     * ```solidity
+     * bytes32 digest = _hashTypedDataV4(keccak256(abi.encode(
+     *     keccak256("Mail(address to,string contents)"),
+     *     mailTo,
+     *     keccak256(bytes(mailContents))
+     * )));
+     * address signer = ECDSA.recover(digest, signature);
+     * ```
+     */
+    function _hashTypedDataV4(
+        bytes32 structHash
+    ) internal view virtual returns (bytes32) {
+        return
+            MessageHashUtils.toTypedDataHash(_domainSeparatorV4(), structHash);
+    }
+
+    /**
+     * @dev See {IERC-5267}.
+     */
+    function eip712Domain()
+        public
+        view
+        virtual
+        returns (
+            bytes1 fields,
+            string memory name,
+            string memory version,
+            uint256 chainId,
+            address verifyingContract,
+            bytes32 salt,
+            uint256[] memory extensions
+        )
+    {
+        return (
+            hex"0f", // 01111
+            _EIP712Name(),
+            _EIP712Version(),
+            block.chainid,
+            address(0),
+            bytes32(0),
+            new uint256[](0)
+        );
+    }
+
+    /**
+     * @dev The name parameter for the EIP712 domain.
+     *
+     * NOTE: By default this function reads _name which is an immutable value.
+     * It only reads from storage if necessary (in case the value is too large to fit in a ShortString).
+     */
+    // solhint-disable-next-line func-name-mixedcase
+    function _EIP712Name() internal view returns (string memory) {
+        return _name.toStringWithFallback(_nameFallback);
+    }
+
+    /**
+     * @dev The version parameter for the EIP712 domain.
+     *
+     * NOTE: By default this function reads _version which is an immutable value.
+     * It only reads from storage if necessary (in case the value is too large to fit in a ShortString).
+     */
+    // solhint-disable-next-line func-name-mixedcase
+    function _EIP712Version() internal view returns (string memory) {
+        return _version.toStringWithFallback(_versionFallback);
+    }
+}

--- a/contracts/access/PermissionedV2.sol
+++ b/contracts/access/PermissionedV2.sol
@@ -1,0 +1,276 @@
+// solhint-disable func-name-mixedcase
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.19 <0.9.0;
+
+import {SignatureChecker} from "@openzeppelin/contracts/utils/cryptography/SignatureChecker.sol";
+import {EIP712} from "./EIP712.sol";
+
+/**
+ * @dev Permission body that must be passed to a contract to allow access to sensitive data.
+ * 
+ * The minimum permission to access a user's own data requires the fields
+ * < issuer, expiration, contracts, projects, sealingKey, issuerSignature >
+ *
+ * `contracts` and `projects` are lists defining which contracts can be accessed with this permission.
+ * `projects` is a list of strings, each of which defines and provides access to a group of contracts.
+ *
+ *   ---
+ *
+ * If not sharing the permission, `issuer` signs a signature using the fields:
+ *     < issuer, expiration, contracts, projects, recipient, validatorId, validatorContract, sealingKey >
+ * This signature can now be used by `issuer` to access their own encrypted data.
+ *
+ *   ---
+ *
+ * Sharing a permission is a two step process: `issuer` completes step 1, and `recipient` completes step 2.
+ *
+ * 1:
+ * `issuer` creates a permission with `recipient` populated with the address of the user to give access to.
+ * `issuer` does not include a `sealingKey` in the permission, it will be populated by the `recipient`.
+ * `issuer` is still responsible for defining the permission's access through `contracts` and `projects`.
+ * `issuer` signs a signature including the fields: (note: `sealingKey` is absent in this signature)
+ *     < issuer, expiration, contracts, projects, recipient, validatorId, validatorContract >
+ * `issuer` packages the permission data and `issuerSignature` and shares it with `recipient`
+ *     ** None of this data is sensitive, and can be shared as cleartext **
+ *
+ * 2:
+ * `recipient` adds their `sealingKey` to the data received from `issuer`
+ * `recipient` signs a signature including the fields:
+ *     < sealingKey, issuerSignature >
+ * `recipient` can now use the completed Permission to access `issuer`s encrypted data.
+ *
+ *   ---
+ *
+ * `validatorId` and `validatorContract` are optional and can be used together to 
+ * increase security and control by disabling a permission after it has been created.
+ * Useful when sharing permits to provide external access to sensitive data (eg auditors).
+ */
+struct PermissionV2 {
+    // (base) User that initially created the permission, target of data fetching
+    address issuer;
+    // (base) Expiration timestamp
+    uint64 expiration;
+    // (base) List of contract addresses that can be accessed with this permission
+    address[] contracts;
+    // (base) List of project identifiers (strings) that can be accessed
+    string[] projects;
+    // (sharing) The user that this permission will be shared with
+    // ** optional, use `address(0)` to disable **
+    address recipient;
+    // (issuer defined validation) An id used to query a contract to check this permissions validity
+    // ** optional, use `0` to disable **
+    uint256 validatorId;
+    // (issuer defined validation) The contract to query to determine permission validity
+    // ** optional, user `address(0)` to disable **
+    address validatorContract;
+    // (base) The publicKey of a sealingPair used to re-encrypt `issuer`s confidential data
+    //   (non-sharing) Populated by `issuer`
+    //   (sharing)     Populated by `recipient` 
+    bytes32 sealingKey;
+    // (base) `signTypedData` signature created by `issuer`.
+    // (base) Shared- and Self- permissions differ in signature format: (`sealingKey` absent in shared signature)
+    //   (non-sharing) < issuer, expiration, contracts, projects, recipient, validatorId, validatorContract, sealingKey >
+    //   (sharing)     < issuer, expiration, contracts, projects, recipient, validatorId, validatorContract >
+    bytes issuerSignature;
+    // (sharing) `signTypedData` signature created by `recipient` with format:
+    // (sharing) < sealingKey, issuerSignature>
+    // ** required for shared permits **
+    bytes recipientSignature;
+}
+
+
+/// @dev Minimum required interface to create a custom permission validator.
+/// Permission validators are optional, and provide extra security and control when sharing permits.
+interface IPermissionValidator {
+    /// @dev Checks whether a permission is valid, returning `false` disables the permission.
+    function disabled(
+        address issuer,
+        uint256 id
+    ) external view returns (bool);
+}
+
+/// @dev Uses a modified version of openzeppelin's EIP712 contract which disables the `verifyingContract`.
+/// Instead, access is checked using the `contracts` and `projects` fields of the `PermissionV2` struct.
+/// This allows a single signed permission to be used to access multiple contracts encrypted data.
+contract PermissionedV2 is EIP712 {
+    using PermissionV2Utils for PermissionV2;
+
+    string public version = "v2.0.0";
+    string public project;
+
+    /// @dev Initialize the PermissionedV2 contract with a `project` identifier string.
+    /// Any Permission with this project identifier in the `projects` list will be granted
+    /// access to this contract's data when protected by the `withPermission` modifier.
+    ///
+    /// NOTE: Ensure that view functions protected by `withPermission` return ONLY the sensitive data of `permission.issuer`.
+    /// !! Returning data of `msg.sender` will leak sensitive values - `msg.sender` cannot be trusted in view functions !!
+    constructor(
+        string memory proj
+    ) EIP712(string.concat("Fhenix Permission ", version), version) {
+        project = proj;
+    }
+
+    error PermissionInvalid_ContractUnauthorized();
+    error PermissionInvalid_Expired();
+    error PermissionInvalid_IssuerSignature();
+    error PermissionInvalid_RecipientSignature();
+    error PermissionInvalid_Disabled();
+
+    /// @dev Validate's a `permissions` access of sensitive data.
+    /// `permission` may be invalid or unauthorized for the following reasons:
+    ///
+    ///    - Contract unauthorized:    `project` is not in `permission.projects` nor address(this) in `permission.contracts`
+    ///    - Expired:                  `permission.expiration` is in the past (< block.timestamp)
+    ///    - Issuer signature:         `issuerSignature` is malformed or was not signed by `permission.issuer`
+    ///    - Recipient signature:      `recipientSignature` is malformed or was not signed by `permission.recipient`
+    ///    - Disabled:                 `validatorContract` returned `false` indicating that this permission has been externally disabled
+    modifier withPermission(PermissionV2 memory permission) {
+        // Access
+        if (!permission.satisfies(address(this), project))
+            revert PermissionInvalid_ContractUnauthorized();
+
+        // Expiration
+        if (permission.expiration < block.timestamp)
+            revert PermissionInvalid_Expired();
+
+        // Issuer signature
+        if (
+            !SignatureChecker.isValidSignatureNow(
+                permission.issuer,
+                _hashTypedDataV4(permission.issuerHash()),
+                permission.issuerSignature
+            )
+        ) revert PermissionInvalid_IssuerSignature();
+
+        // (if applicable) Recipient signature
+        if (
+            permission.recipient != address(0) &&
+            !SignatureChecker.isValidSignatureNow(
+                permission.recipient,
+                _hashTypedDataV4(permission.recipientHash()),
+                permission.recipientSignature
+            )
+        ) revert PermissionInvalid_RecipientSignature();
+
+        // (if applicable) Externally disabled
+        if (
+            permission.validatorId != 0 &&
+            permission.validatorContract != address(0) &&
+            IPermissionValidator(permission.validatorContract).disabled(
+                permission.issuer,
+                permission.validatorId
+            )
+        ) revert PermissionInvalid_Disabled();
+
+        _;
+    }
+
+    /// @dev Utility function used to check whether a permission provides access to this contract.
+    /// Intended to be used before real data is fetched to preempt a reversion, but is not necessary to use.
+    function checkPermissionSatisfies(
+        PermissionV2 memory permission
+    ) external view returns (bool) {
+        return permission.satisfies(address(this), project);
+    }
+}
+
+/// @dev Internal utility library to improve the readability of PermissionedV2
+/// Primarily focused on signature type hashes
+library PermissionV2Utils {
+    function issuerHash(
+        PermissionV2 memory permission
+    ) internal pure returns (bytes32) {
+        if (permission.recipient == address(0))
+            return issuerSelfHash(permission);
+        return issuerSharedHash(permission);
+    }
+
+    function issuerSelfHash(
+        PermissionV2 memory permission
+    ) internal pure returns (bytes32) {
+        return
+            keccak256(
+                abi.encode(
+                    keccak256(
+                        "PermissionedV2IssuerSelf(address issuer,uint64 expiration,address[] contracts,string[] projects,address recipient,uint256 validatorId,address validatorContract,bytes32 sealingKey)"
+                    ),
+                    permission.issuer,
+                    permission.expiration,
+                    encodeArray(permission.contracts),
+                    encodeArray(permission.projects),
+                    permission.recipient,
+                    permission.validatorId,
+                    permission.validatorContract,
+                    permission.sealingKey
+                )
+            );
+    }
+
+    function issuerSharedHash(
+        PermissionV2 memory permission
+    ) internal pure returns (bytes32) {
+        return
+            keccak256(
+                abi.encode(
+                    keccak256(
+                        "PermissionedV2IssuerShared(address issuer,uint64 expiration,address[] contracts,string[] projects,address recipient,uint256 validatorId,address validatorContract)"
+                    ),
+                    permission.issuer,
+                    permission.expiration,
+                    encodeArray(permission.contracts),
+                    encodeArray(permission.projects),
+                    permission.recipient,
+                    permission.validatorId,
+                    permission.validatorContract
+                )
+            );
+    }
+
+    function recipientHash(
+        PermissionV2 memory permission
+    ) internal pure returns (bytes32) {
+        return
+            keccak256(
+                abi.encode(
+                    keccak256(
+                        "PermissionedV2Recipient(bytes32 sealingKey,bytes issuerSignature)"
+                    ),
+                    permission.sealingKey,
+                    keccak256(permission.issuerSignature)
+                )
+            );
+    }
+
+    function satisfies(
+        PermissionV2 memory permission,
+        address addr,
+        string memory proj
+    ) internal pure returns (bool) {
+        for (uint256 i = 0; i < permission.projects.length; i++) {
+            if (
+                keccak256(abi.encodePacked(proj)) ==
+                keccak256(abi.encodePacked(permission.projects[i]))
+            ) return true;
+        }
+        for (uint256 i = 0; i < permission.contracts.length; i++) {
+            if (addr == permission.contracts[i]) return true;
+        }
+        return false;
+    }
+
+    function encodeArray(
+        address[] memory items
+    ) internal pure returns (bytes32) {
+        return keccak256(abi.encodePacked(items));
+    }
+
+    function encodeArray(
+        string[] memory items
+    ) internal pure returns (bytes32) {
+        bytes32[] memory result = new bytes32[](items.length);
+        for (uint256 i = 0; i < items.length; i++) {
+            result[i] = keccak256(bytes(items[i]));
+        }
+        return keccak256(abi.encodePacked(result));
+    }
+}

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -1,31 +1,31 @@
 {
-  "name": "@fhenixprotocol/contracts",
-  "description": "Smart Contract Library for the Fhenix Blockchain with FHE primitives",
-  "version": "0.3.0-alpha.4",
-  "author": {
-    "name": "FhenixProtocol",
-    "url": "https://github.com/fhenixprotocol/fhenix-contracts"
-  },
-  "dependencies": {
-    "@openzeppelin/contracts": "^5.0.0"
-  },
-  "files": [
-    "FHE.sol",
-    "FheOS.sol",
-    "access/**",
-    "experimental/**",
-    "utils/**"
-  ],
-  "keywords": [
-    "blockchain",
-    "ethereum",
-    "smart-contracts",
-    "solidity",
-    "FHE",
-    "encryption",
-    "privacy"
-  ],
-  "publishConfig": {
-    "access": "public"
-  }
+	"name": "@fhenixprotocol/contracts",
+	"description": "Smart Contract Library for the Fhenix Blockchain with FHE primitives",
+	"version": "0.3.0-alpha.4",
+	"author": {
+		"name": "FhenixProtocol",
+		"url": "https://github.com/fhenixprotocol/fhenix-contracts"
+	},
+	"files": [
+		"FHE.sol",
+		"FheOS.sol",
+		"access/**",
+		"experimental/**",
+		"utils/**"
+	],
+	"keywords": [
+		"blockchain",
+		"ethereum",
+		"smart-contracts",
+		"solidity",
+		"FHE",
+		"encryption",
+		"privacy"
+	],
+	"publishConfig": {
+		"access": "public"
+	},
+	"dependencies": {
+		"@openzeppelin/contracts": "^5.0.0"
+	}
 }

--- a/contracts/test/PermissionedV2Counter.sol
+++ b/contracts/test/PermissionedV2Counter.sol
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.13 <0.9.0;
+
+import "../FHE.sol";
+import {PermissionedV2, PermissionV2} from "../access/PermissionedV2.sol";
+
+contract PermissionedV2Counter is PermissionedV2 {
+    mapping(address => euint32) private userCounter;
+    address public owner;
+
+    constructor() PermissionedV2("COUNTER") {
+        owner = msg.sender;
+    }
+
+    function add(inEuint32 calldata encryptedValue) public {
+        euint32 value = FHE.asEuint32(encryptedValue);
+        userCounter[msg.sender] = userCounter[msg.sender] + value;
+    }
+
+    function getCounter(address user) public view returns (uint256) {
+        return FHE.decrypt(userCounter[user]);
+    }
+
+    function getCounterPermit(
+        PermissionV2 memory permission
+    ) public view withPermission(permission) returns (uint256) {
+        return FHE.decrypt(userCounter[permission.issuer]);
+    }
+
+    function getCounterPermitSealed(
+        PermissionV2 memory permission
+    ) public view withPermission(permission) returns (string memory) {
+        return
+            FHE.sealoutput(
+                userCounter[permission.issuer],
+                permission.sealingKey
+            );
+    }
+}

--- a/contracts/test/PermissionedV2Validators.sol
+++ b/contracts/test/PermissionedV2Validators.sol
@@ -1,0 +1,42 @@
+// solhint-disable func-name-mixedcase
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.19 <0.9.0;
+
+import {IPermissionValidator, PermissionV2} from "../access/PermissionedV2.sol";
+
+contract PermissionedV2RevokableValidator is IPermissionValidator {
+    uint256 public rid = 1;
+    mapping(uint256 => bool) public revoked;
+    mapping(uint256 => address) public owner;
+
+    function createRevokableId() public returns (uint256) {
+        uint256 id = rid;
+        rid += 1;
+
+        revoked[id] = false;
+        owner[id] = msg.sender;
+
+        return id;
+    }
+
+    function revokeId(uint256 id) public {
+        require(owner[id] == msg.sender, "Not owner of id");
+        revoked[id] = true;
+    }
+
+    function disabled(address, uint256 id) external view returns (bool) {
+        return revoked[id];
+    }
+}
+
+contract PermissionedV2TimestampValidator is IPermissionValidator {
+    mapping(address => uint256) public userLastRevokedTimestamp;
+
+    function revokeExisting() public {
+        userLastRevokedTimestamp[msg.sender] = block.timestamp;
+    }
+
+    function disabled(address issuer, uint256 id) external view returns (bool) {
+        return id < userLastRevokedTimestamp[issuer];
+    }
+}

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -1,45 +1,51 @@
-const docgen = require('solidity-docgen');
+const docgen = require('solidity-docgen')
 
-require('@nomiclabs/hardhat-truffle5');
-require('hardhat-exposed');
-require('fhenix-hardhat-plugin');
-require('@nomicfoundation/hardhat-ethers');
+import '@nomicfoundation/hardhat-toolbox'
+
+require('@nomiclabs/hardhat-truffle5')
+require('hardhat-exposed')
+import '@nomicfoundation/hardhat-ethers'
+import 'fhenix-hardhat-plugin'
 
 const config = {
-  defaultNetwork: "localfhenix",
-  networks: {
-    localfhenix: {
-      url: "http://localhost:42069",
-      // chainId: TESTNET_CHAIN_ID,
-      // gas: "auto",
-      // gasMultiplier: 1.2,
-      // gasPrice: "auto",
-      // httpHeaders: {},
-      timeout: 10_000,
-      accounts: {
-        mnemonic: "demand hotel mass rally sphere tiger measure sick spoon evoke fashion comfort",
-        path: "m/44'/60'/0'/0",
-        count: 10,
-        // passphrase: "",
-      },
-    },
-  },
-  paths: {
-    artifacts: "./artifacts",
-    cache: "./cache",
-    sources: "./contracts",
-  },
-  solidity: {
-    version: "0.8.20",
-  },
-  docgen: {
-      pages: "items"
-  },
-  exposed: {
-    imports: true,
-    initializers: true,
-    exclude: ['vendor/**/*'],
-  },
-};
-  
-module.exports = config;
+	defaultNetwork: 'localfhenix',
+	networks: {
+		localfhenix: {
+			url: 'http://localhost:42069',
+			// chainId: TESTNET_CHAIN_ID,
+			// gas: "auto",
+			// gasMultiplier: 1.2,
+			// gasPrice: "auto",
+			// httpHeaders: {},
+			timeout: 10_000,
+			accounts: {
+				mnemonic: 'demand hotel mass rally sphere tiger measure sick spoon evoke fashion comfort',
+				path: "m/44'/60'/0'/0",
+				count: 10,
+				// passphrase: "",
+			},
+		},
+	},
+	paths: {
+		artifacts: './artifacts',
+		cache: './cache',
+		sources: './contracts',
+	},
+	solidity: {
+		version: '0.8.20',
+	},
+	docgen: {
+		pages: 'items',
+	},
+	exposed: {
+		imports: true,
+		initializers: true,
+		exclude: ['vendor/**/*'],
+	},
+	typechain: {
+		outDir: 'types',
+		target: 'ethers-v6',
+	},
+}
+
+module.exports = config

--- a/package.json
+++ b/package.json
@@ -1,39 +1,50 @@
 {
-  "name": "@fhenixprotocol/fhe",
-  "description": "",
-  "version": "0.0.1",
-  "author": {
-    "name": "Fhenix",
-    "url": "https://github.com/fhenixprotocol/fhenix-contracts"
-  },
-  "devDependencies": {
-    "@nomicfoundation/hardhat-ethers": "^3.0.5",
-    "@nomiclabs/hardhat-truffle5": "^2.0.5",
-    "@openzeppelin/contracts": "^5.0.2",
-    "@openzeppelin/test-helpers": "^0.5.13",
-    "chai": "^4.2.0",
-    "fhenix-hardhat-plugin": "^0.2.1",
-    "hardhat": "2.19.3",
-    "hardhat-exposed": "^0.3.13",
-    "solidity-docgen": "0.6.0-beta.36",
-    "typescript": "^5.5.4",
-    "ts-node": "^10.9.2"
-  },
-  "files": [
-    "contracts"
-  ],
-  "keywords": [
-    "blockchain",
-    "ethereum",
-    "smart-contracts",
-    "solidity"
-  ],
-  "publishConfig": {
-    "access": "public"
-  },
-  "scripts": {
-    "docgen": "hardhat docgen",
-    "compile": "hardhat compile",
-    "test": "hardhat test"
-  }
+	"name": "@fhenixprotocol/fhe",
+	"description": "",
+	"version": "0.0.1",
+	"author": {
+		"name": "Fhenix",
+		"url": "https://github.com/fhenixprotocol/fhenix-contracts"
+	},
+	"devDependencies": {
+		"@nomicfoundation/hardhat-ethers": "^3.0.5",
+		"@nomicfoundation/hardhat-network-helpers": "^1.0.10",
+		"@nomiclabs/hardhat-truffle5": "^2.0.5",
+		"@openzeppelin/contracts": "^5.0.2",
+		"@openzeppelin/test-helpers": "^0.5.13",
+		"fhenix-hardhat-docker": "0.3.0-alpha.2",
+		"fhenix-hardhat-plugin": "0.3.0-alpha.2",
+		"hardhat": "2.19.3",
+		"hardhat-exposed": "^0.3.13",
+		"solidity-docgen": "0.6.0-beta.36",
+		"typescript": "^5.5.4",
+		"ts-node": "^10.9.2",
+		"@types/chai": "^4.3.11",
+		"chai": "^4.3.7",
+		"@types/mocha": "^10.0.6",
+		"mocha": "^10.3.0",
+		"@typechain/ethers-v6": "^0.5.1",
+		"@typechain/hardhat": "^9.1.0",
+		"typechain": "^8.3.2",
+		"@nomicfoundation/hardhat-toolbox": "^4.0.0",
+		"ethers": "^6.11.1",
+		"fhenixjs": "0.4.0-alpha.6"
+	},
+	"files": [
+		"contracts"
+	],
+	"keywords": [
+		"blockchain",
+		"ethereum",
+		"smart-contracts",
+		"solidity"
+	],
+	"publishConfig": {
+		"access": "public"
+	},
+	"scripts": {
+		"docgen": "hardhat docgen",
+		"compile": "hardhat compile",
+		"test": "hardhat test"
+	}
 }

--- a/package.json
+++ b/package.json
@@ -6,29 +6,10 @@
 		"name": "Fhenix",
 		"url": "https://github.com/fhenixprotocol/fhenix-contracts"
 	},
-	"devDependencies": {
-		"@nomicfoundation/hardhat-ethers": "^3.0.5",
-		"@nomicfoundation/hardhat-network-helpers": "^1.0.10",
-		"@nomiclabs/hardhat-truffle5": "^2.0.5",
-		"@openzeppelin/contracts": "^5.0.2",
-		"@openzeppelin/test-helpers": "^0.5.13",
-		"fhenix-hardhat-docker": "0.3.0-alpha.2",
-		"fhenix-hardhat-plugin": "0.3.0-alpha.2",
-		"hardhat": "2.19.3",
-		"hardhat-exposed": "^0.3.13",
-		"solidity-docgen": "0.6.0-beta.36",
-		"typescript": "^5.5.4",
-		"ts-node": "^10.9.2",
-		"@types/chai": "^4.3.11",
-		"chai": "^4.3.7",
-		"@types/mocha": "^10.0.6",
-		"mocha": "^10.3.0",
-		"@typechain/ethers-v6": "^0.5.1",
-		"@typechain/hardhat": "^9.1.0",
-		"typechain": "^8.3.2",
-		"@nomicfoundation/hardhat-toolbox": "^4.0.0",
-		"ethers": "^6.11.1",
-		"fhenixjs": "0.4.0-alpha.6"
+	"scripts": {
+		"docgen": "hardhat docgen",
+		"compile": "hardhat compile",
+		"test": "hardhat test"
 	},
 	"files": [
 		"contracts"
@@ -42,9 +23,28 @@
 	"publishConfig": {
 		"access": "public"
 	},
-	"scripts": {
-		"docgen": "hardhat docgen",
-		"compile": "hardhat compile",
-		"test": "hardhat test"
+	"devDependencies": {
+		"@nomicfoundation/hardhat-ethers": "^3.0.5",
+		"@nomicfoundation/hardhat-network-helpers": "^1.0.10",
+		"@nomicfoundation/hardhat-toolbox": "^4.0.0",
+		"@nomiclabs/hardhat-truffle5": "^2.0.5",
+		"@openzeppelin/contracts": "^5.0.2",
+		"@openzeppelin/test-helpers": "^0.5.13",
+		"@typechain/ethers-v6": "^0.5.1",
+		"@typechain/hardhat": "^9.1.0",
+		"@types/chai": "^4.3.11",
+		"@types/mocha": "^10.0.6",
+		"chai": "^4.3.7",
+		"ethers": "^6.11.1",
+		"fhenix-hardhat-docker": "0.3.0-alpha.2",
+		"fhenix-hardhat-plugin": "0.3.0-alpha.2",
+		"fhenixjs": "0.4.0-alpha.6",
+		"hardhat-exposed": "^0.3.13",
+		"hardhat": "2.19.3",
+		"mocha": "^10.3.0",
+		"solidity-docgen": "0.6.0-beta.36",
+		"ts-node": "^10.9.2",
+		"typechain": "^8.3.2",
+		"typescript": "^5.5.4"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,34 +10,67 @@ importers:
     devDependencies:
       '@nomicfoundation/hardhat-ethers':
         specifier: ^3.0.5
-        version: 3.0.6(ethers@6.13.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))(hardhat@2.19.3(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@18.15.13)(typescript@5.5.4))(typescript@5.5.4)(utf-8-validate@5.0.10))
+        version: 3.0.6(ethers@6.13.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))(hardhat@2.19.3(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@20.17.6)(typescript@5.5.4))(typescript@5.5.4)(utf-8-validate@5.0.10))
+      '@nomicfoundation/hardhat-network-helpers':
+        specifier: ^1.0.10
+        version: 1.0.12(hardhat@2.19.3(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@20.17.6)(typescript@5.5.4))(typescript@5.5.4)(utf-8-validate@5.0.10))
+      '@nomicfoundation/hardhat-toolbox':
+        specifier: ^4.0.0
+        version: 4.0.0(uezshn5bctuovpk5pjox5apymi)
       '@nomiclabs/hardhat-truffle5':
         specifier: ^2.0.5
-        version: 2.0.7(@nomiclabs/hardhat-web3@2.0.0(hardhat@2.19.3(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@18.15.13)(typescript@5.5.4))(typescript@5.5.4)(utf-8-validate@5.0.10))(web3@1.10.4(bufferutil@4.0.8)(utf-8-validate@5.0.10)))(bufferutil@4.0.8)(hardhat@2.19.3(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@18.15.13)(typescript@5.5.4))(typescript@5.5.4)(utf-8-validate@5.0.10))(utf-8-validate@5.0.10)(web3-core-helpers@1.10.4)(web3-core-promievent@1.10.4)(web3-eth-abi@1.10.4)(web3-utils@1.10.4)(web3@1.10.4(bufferutil@4.0.8)(utf-8-validate@5.0.10))
+        version: 2.0.7(@nomiclabs/hardhat-web3@2.0.0(hardhat@2.19.3(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@20.17.6)(typescript@5.5.4))(typescript@5.5.4)(utf-8-validate@5.0.10))(web3@1.10.4(bufferutil@4.0.8)(utf-8-validate@5.0.10)))(bufferutil@4.0.8)(hardhat@2.19.3(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@20.17.6)(typescript@5.5.4))(typescript@5.5.4)(utf-8-validate@5.0.10))(utf-8-validate@5.0.10)(web3-core-helpers@1.10.4)(web3-core-promievent@1.10.4)(web3-eth-abi@1.10.4)(web3-utils@1.10.4)(web3@1.10.4(bufferutil@4.0.8)(utf-8-validate@5.0.10))
       '@openzeppelin/contracts':
         specifier: ^5.0.2
         version: 5.0.2
       '@openzeppelin/test-helpers':
         specifier: ^0.5.13
         version: 0.5.16(bn.js@5.2.1)(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      '@typechain/ethers-v6':
+        specifier: ^0.5.1
+        version: 0.5.1(ethers@6.13.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))(typechain@8.3.2(typescript@5.5.4))(typescript@5.5.4)
+      '@typechain/hardhat':
+        specifier: ^9.1.0
+        version: 9.1.0(@typechain/ethers-v6@0.5.1(ethers@6.13.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))(typechain@8.3.2(typescript@5.5.4))(typescript@5.5.4))(ethers@6.13.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))(hardhat@2.19.3(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@20.17.6)(typescript@5.5.4))(typescript@5.5.4)(utf-8-validate@5.0.10))(typechain@8.3.2(typescript@5.5.4))
+      '@types/chai':
+        specifier: ^4.3.11
+        version: 4.3.16
+      '@types/mocha':
+        specifier: ^10.0.6
+        version: 10.0.9
       chai:
-        specifier: ^4.2.0
+        specifier: ^4.3.7
         version: 4.4.1
+      ethers:
+        specifier: ^6.11.1
+        version: 6.13.1(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      fhenix-hardhat-docker:
+        specifier: 0.3.0-alpha.2
+        version: 0.3.0-alpha.2(hardhat@2.19.3(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@20.17.6)(typescript@5.5.4))(typescript@5.5.4)(utf-8-validate@5.0.10))
       fhenix-hardhat-plugin:
-        specifier: ^0.2.1
-        version: 0.2.1(bufferutil@4.0.8)(hardhat@2.19.3(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@18.15.13)(typescript@5.5.4))(typescript@5.5.4)(utf-8-validate@5.0.10))(utf-8-validate@5.0.10)
+        specifier: 0.3.0-alpha.2
+        version: 0.3.0-alpha.2(bufferutil@4.0.8)(hardhat@2.19.3(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@20.17.6)(typescript@5.5.4))(typescript@5.5.4)(utf-8-validate@5.0.10))(utf-8-validate@5.0.10)
+      fhenixjs:
+        specifier: 0.4.0-alpha.6
+        version: 0.4.0-alpha.6
       hardhat:
         specifier: 2.19.3
-        version: 2.19.3(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@18.15.13)(typescript@5.5.4))(typescript@5.5.4)(utf-8-validate@5.0.10)
+        version: 2.19.3(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@20.17.6)(typescript@5.5.4))(typescript@5.5.4)(utf-8-validate@5.0.10)
       hardhat-exposed:
         specifier: ^0.3.13
-        version: 0.3.15(hardhat@2.19.3(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@18.15.13)(typescript@5.5.4))(typescript@5.5.4)(utf-8-validate@5.0.10))
+        version: 0.3.15(hardhat@2.19.3(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@20.17.6)(typescript@5.5.4))(typescript@5.5.4)(utf-8-validate@5.0.10))
+      mocha:
+        specifier: ^10.3.0
+        version: 10.8.2
       solidity-docgen:
         specifier: 0.6.0-beta.36
-        version: 0.6.0-beta.36(hardhat@2.19.3(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@18.15.13)(typescript@5.5.4))(typescript@5.5.4)(utf-8-validate@5.0.10))
+        version: 0.6.0-beta.36(hardhat@2.19.3(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@20.17.6)(typescript@5.5.4))(typescript@5.5.4)(utf-8-validate@5.0.10))
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@types/node@18.15.13)(typescript@5.5.4)
+        version: 10.9.2(@types/node@20.17.6)(typescript@5.5.4)
+      typechain:
+        specifier: ^8.3.2
+        version: 8.3.2(typescript@5.5.4)
       typescript:
         specifier: ^5.5.4
         version: 5.5.4
@@ -229,6 +262,18 @@ packages:
   '@noble/secp256k1@1.7.1':
     resolution: {integrity: sha512-hOUk6AyBFmqVrv7k5WAw/LpszxVbj9gGN4JRkIX52fdFAj1UA61KXmZDvqVEm+pOyec3+fIeZB02LYa/pWOArw==}
 
+  '@nodelib/fs.scandir@2.1.5':
+    resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
+    engines: {node: '>= 8'}
+
+  '@nodelib/fs.stat@2.0.5':
+    resolution: {integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==}
+    engines: {node: '>= 8'}
+
+  '@nodelib/fs.walk@1.2.8':
+    resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
+    engines: {node: '>= 8'}
+
   '@nomicfoundation/ethereumjs-block@5.0.2':
     resolution: {integrity: sha512-hSe6CuHI4SsSiWWjHDIzWhSiAVpzMUcDRpWYzN0T9l8/Rz7xNn3elwVOJ/tAyS0LqL6vitUD78Uk7lQDXZun7Q==}
     engines: {node: '>=14'}
@@ -272,11 +317,50 @@ packages:
     resolution: {integrity: sha512-Bj3KZT64j54Tcwr7Qm/0jkeZXJMfdcAtRBedou+Hx0dPOSIgqaIr0vvLwP65TpHbak2DmAq+KJbW2KNtIoFwvA==}
     engines: {node: '>=14'}
 
+  '@nomicfoundation/hardhat-chai-matchers@2.0.8':
+    resolution: {integrity: sha512-Z5PiCXH4xhNLASROlSUOADfhfpfhYO6D7Hn9xp8PddmHey0jq704cr6kfU8TRrQ4PUZbpfsZadPj+pCfZdjPIg==}
+    peerDependencies:
+      '@nomicfoundation/hardhat-ethers': ^3.0.0
+      chai: ^4.2.0
+      ethers: ^6.1.0
+      hardhat: ^2.9.4
+
   '@nomicfoundation/hardhat-ethers@3.0.6':
     resolution: {integrity: sha512-/xzkFQAaHQhmIAYOQmvHBPwL+NkwLzT9gRZBsgWUYeV+E6pzXsBQsHfRYbAZ3XEYare+T7S+5Tg/1KDJgepSkA==}
     peerDependencies:
       ethers: ^6.1.0
       hardhat: ^2.0.0
+
+  '@nomicfoundation/hardhat-network-helpers@1.0.12':
+    resolution: {integrity: sha512-xTNQNI/9xkHvjmCJnJOTyqDSl8uq1rKb2WOVmixQxFtRd7Oa3ecO8zM0cyC2YmOK+jHB9WPZ+F/ijkHg1CoORA==}
+    peerDependencies:
+      hardhat: ^2.9.5
+
+  '@nomicfoundation/hardhat-toolbox@4.0.0':
+    resolution: {integrity: sha512-jhcWHp0aHaL0aDYj8IJl80v4SZXWMS1A2XxXa1CA6pBiFfJKuZinCkO6wb+POAt0LIfXB3gA3AgdcOccrcwBwA==}
+    peerDependencies:
+      '@nomicfoundation/hardhat-chai-matchers': ^2.0.0
+      '@nomicfoundation/hardhat-ethers': ^3.0.0
+      '@nomicfoundation/hardhat-network-helpers': ^1.0.0
+      '@nomicfoundation/hardhat-verify': ^2.0.0
+      '@typechain/ethers-v6': ^0.5.0
+      '@typechain/hardhat': ^9.0.0
+      '@types/chai': ^4.2.0
+      '@types/mocha': '>=9.1.0'
+      '@types/node': '>=16.0.0'
+      chai: ^4.2.0
+      ethers: ^6.4.0
+      hardhat: ^2.11.0
+      hardhat-gas-reporter: ^1.0.8
+      solidity-coverage: ^0.8.1
+      ts-node: '>=8.0.0'
+      typechain: ^8.3.0
+      typescript: '>=4.5.0'
+
+  '@nomicfoundation/hardhat-verify@2.0.11':
+    resolution: {integrity: sha512-lGIo4dNjVQFdsiEgZp3KP6ntLiF7xJEJsbNHfSyIiFCyI0Yv0518ElsFtMC5uCuHEChiBBMrib9jWQvHHT+X3Q==}
+    peerDependencies:
+      hardhat: ^2.0.4
 
   '@nomicfoundation/solidity-analyzer-darwin-arm64@0.1.1':
     resolution: {integrity: sha512-KcTodaQw8ivDZyF+D76FokN/HdpgGpfjc/gFCImdLUyqB6eSWVaZPazMbeAjmfhx3R0zm/NYVzxwAokFKgrc0w==}
@@ -423,6 +507,12 @@ packages:
     resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==}
     engines: {node: '>=10'}
 
+  '@solidity-parser/parser@0.14.5':
+    resolution: {integrity: sha512-6dKnHZn7fg/iQATVEzqyUOyEidbn05q7YA2mQ9hC0MMXhhV3/JrsxmFSYZAcr7j1yUP700LLhTruvJ3MiQmjJg==}
+
+  '@solidity-parser/parser@0.18.0':
+    resolution: {integrity: sha512-yfORGUIPgLck41qyN7nbwJRAx17/jAIXCTanHOJZhB6PJ1iAk/84b/xlsVKFSyNyLXIj0dhppoE0+CRws7wlzA==}
+
   '@szmarczak/http-timer@4.0.6':
     resolution: {integrity: sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==}
     engines: {node: '>=10'}
@@ -495,6 +585,21 @@ packages:
   '@tsconfig/node16@1.0.4':
     resolution: {integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==}
 
+  '@typechain/ethers-v6@0.5.1':
+    resolution: {integrity: sha512-F+GklO8jBWlsaVV+9oHaPh5NJdd6rAKN4tklGfInX1Q7h0xPgVLP39Jl3eCulPB5qexI71ZFHwbljx4ZXNfouA==}
+    peerDependencies:
+      ethers: 6.x
+      typechain: ^8.3.2
+      typescript: '>=4.7.0'
+
+  '@typechain/hardhat@9.1.0':
+    resolution: {integrity: sha512-mtaUlzLlkqTlfPwB3FORdejqBskSnh+Jl8AIJGjXNAQfRQ4ofHADPl1+oU7Z3pAJzmZbUXII8MhOLQltcHgKnA==}
+    peerDependencies:
+      '@typechain/ethers-v6': ^0.5.1
+      ethers: ^6.1.0
+      hardhat: ^2.9.9
+      typechain: ^8.3.2
+
   '@types/bignumber.js@5.0.0':
     resolution: {integrity: sha512-0DH7aPGCClywOFaxxjE6UwpN2kQYe9LwuDQMv+zYA97j5GkOMo8e66LYT+a8JYU7jfmUFRZLa9KycxHDsKXJCA==}
     deprecated: This is a stub types definition for bignumber.js (https://github.com/MikeMcl/bignumber.js/). bignumber.js provides its own type definitions, so you don't need @types/bignumber.js installed!
@@ -508,8 +613,20 @@ packages:
   '@types/cacheable-request@6.0.3':
     resolution: {integrity: sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==}
 
+  '@types/chai-as-promised@7.1.8':
+    resolution: {integrity: sha512-ThlRVIJhr69FLlh6IctTXFkmhtP3NpMZ2QGq69StYLyKZFp/HOp1VdKZj7RvfNWYYcJ1xlbLGLLWj1UvP5u/Gw==}
+
   '@types/chai@4.3.16':
     resolution: {integrity: sha512-PatH4iOdyh3MyWtmHVFXLWCCIhUbopaltqddG9BzB+gMIzee2MJrvd+jouii9Z3wzQJruGWAm7WOMjgfG8hQlQ==}
+
+  '@types/concat-stream@1.6.1':
+    resolution: {integrity: sha512-eHE4cQPoj6ngxBZMvVf6Hw7Mh4jMW4U9lpGmS5GBPB9RYxlFg+CHaVN7ErNY4W9XfLIEn20b4VDYaIrbq0q4uA==}
+
+  '@types/form-data@0.0.33':
+    resolution: {integrity: sha512-8BSvG1kGm83cyJITQMZSulnl6QV8jqAGreJsc5tPu1Jq0vTSOiY/k24Wx82JRpWwZSqrala6sd5rWi6aNXvqcw==}
+
+  '@types/glob@7.2.0':
+    resolution: {integrity: sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==}
 
   '@types/http-cache-semantics@4.0.4':
     resolution: {integrity: sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA==}
@@ -520,14 +637,35 @@ packages:
   '@types/lru-cache@5.1.1':
     resolution: {integrity: sha512-ssE3Vlrys7sdIzs5LOxCzTVMsU7i9oa/IaW92wF32JFb3CVczqOkru2xspuKczHEbG3nvmPY7IFqVmGGHdNbYw==}
 
+  '@types/minimatch@5.1.2':
+    resolution: {integrity: sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==}
+
+  '@types/mocha@10.0.9':
+    resolution: {integrity: sha512-sicdRoWtYevwxjOHNMPTl3vSfJM6oyW8o1wXeI7uww6b6xHg8eBznQDNSGBCDJmsE8UMxP05JgZRtsKbTqt//Q==}
+
+  '@types/node@10.17.60':
+    resolution: {integrity: sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==}
+
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
 
   '@types/node@18.15.13':
     resolution: {integrity: sha512-N+0kuo9KgrUQ1Sn/ifDXsvg0TTleP7rIy4zOBGECxAljqvqfqpTfzx0Q1NUedOixRMBfe2Whhb056a42cWs26Q==}
 
+  '@types/node@20.17.6':
+    resolution: {integrity: sha512-VEI7OdvK2wP7XHnsuXbAJnEpEkF6NjSN45QJlL4VGqZSXsnicpesdTWsg9RISeSdYd3yeRj/y3k5KGjUXYnFwQ==}
+
+  '@types/node@8.10.66':
+    resolution: {integrity: sha512-tktOkFUA4kXx2hhhrB8bIFb5TbwzS4uOhKEmwiD+NoiL0qtP2OQ9mFldbgD4dV1djrlBYP6eBuQZiWjuHUpqFw==}
+
   '@types/pbkdf2@3.1.0':
     resolution: {integrity: sha512-Cf63Rv7jCQ0LaL8tNXmEyqTHuIJxRdlS5vMh1mj5voN4+QFhVZnlZruezqpWYDiJ8UTzhP0VmeLXCmBk66YrMQ==}
+
+  '@types/prettier@2.7.3':
+    resolution: {integrity: sha512-+68kP9yzs4LMp7VNh8gdzMSPZFL44MLGqiHWvttYJe+6qnuVr4Ek9wSBQoveqY/r+LwjCcU29kNVkidwim+kYA==}
+
+  '@types/qs@6.9.17':
+    resolution: {integrity: sha512-rX4/bPcfmvxHDv0XjfJELTTr+iB+tn032nPILqHm5wbthUUUuVtNGGqzhya9XUxjTP8Fpr0qYgSZZKxGY++svQ==}
 
   '@types/readable-stream@2.3.15':
     resolution: {integrity: sha512-oM5JSKQCcICF1wvGgmecmHldZ48OZamtMxcGGVICOJA8o8cahXC1zEVAif8iwoc5j8etxFaRFnf095+CDsuoFQ==}
@@ -537,6 +675,9 @@ packages:
 
   '@types/secp256k1@4.0.3':
     resolution: {integrity: sha512-Da66lEIFeIz9ltsdMZcpQvmrmmoqrfju8pm1BH8WbYjZSwUgCwXLb9C+9XYogwBITnbsSaMdVPb2ekf7TV+03w==}
+
+  abbrev@1.0.9:
+    resolution: {integrity: sha512-LEyx4aLEC3x6T0UguF6YILf+ntvmOaWsVfENmIW0E9H09vKlLDGelMjjSm0jkDHALj8A8quZ/HapKNigzwge+Q==}
 
   abortcontroller-polyfill@1.7.5:
     resolution: {integrity: sha512-JMJ5soJWP18htbbxJjG7bG6yuI6pRhgJ0scHHTfkUjf6wjP912xZWvM+A4sJK3gqd9E8fcPbDnOefbA9Th/FIQ==}
@@ -579,12 +720,15 @@ packages:
   ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
 
+  ajv@8.17.1:
+    resolution: {integrity: sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==}
+
+  amdefine@1.0.1:
+    resolution: {integrity: sha512-S2Hw0TtNkMJhIabBwIojKL9YHO5T0n5eNqWJ7Lrlel/zDbftQpxpapi8tZs3X1HWa+u+QeydGmzzNU0m09+Rcg==}
+    engines: {node: '>=0.4.2'}
+
   ansi-colors@3.2.4:
     resolution: {integrity: sha512-hHUXGagefjN2iRrID63xckIvotOXOojhQKWIPUZ4mNUZ9nLZW+7FMNoE1lOkEhNWYsx/7ysGIuJYCiMAA9FnrA==}
-    engines: {node: '>=6'}
-
-  ansi-colors@4.1.1:
-    resolution: {integrity: sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==}
     engines: {node: '>=6'}
 
   ansi-colors@4.1.3:
@@ -615,6 +759,9 @@ packages:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
+  antlr4ts@0.5.0-alpha.4:
+    resolution: {integrity: sha512-WPQDt1B74OfPv/IMS2ekXAKkTZIHl88uMetg6q3OTqgFxZ/dxDXI0EWLyZid/1Pe6hTftyg5N7gel5wNAGxXyQ==}
+
   anymatch@3.1.3:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
@@ -622,14 +769,33 @@ packages:
   arg@4.1.3:
     resolution: {integrity: sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==}
 
+  argparse@1.0.10:
+    resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
+
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  array-back@3.1.0:
+    resolution: {integrity: sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==}
+    engines: {node: '>=6'}
+
+  array-back@4.0.2:
+    resolution: {integrity: sha512-NbdMezxqf94cnNfWLL7V/im0Ub+Anbb0IoZhvzie8+4HJ4nMQuzHuy49FkGYCJK2yAloZ3meiB6AVMClbrI1vg==}
+    engines: {node: '>=8'}
 
   array-buffer-byte-length@1.0.0:
     resolution: {integrity: sha512-LPuwb2P+NrQw3XhxGc36+XSvuBPopovXYTR9Ew++Du9Yb/bx5AzBfrIsBoj0EZUifjQU+sHL21sseZ3jerWO/A==}
 
   array-flatten@1.1.1:
     resolution: {integrity: sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==}
+
+  array-union@2.1.0:
+    resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
+    engines: {node: '>=8'}
+
+  array-uniq@1.0.3:
+    resolution: {integrity: sha512-MNha4BWQ6JbwhFhj03YK552f7cb3AzoE8SzeljgChvL1dl3IcvggXVz1DilzySZkCja+CXuZbdW7yATchWn8/Q==}
+    engines: {node: '>=0.10.0'}
 
   array.prototype.findlast@1.2.3:
     resolution: {integrity: sha512-kcBubumjciBg4JKp5KTKtI7ec7tRefPk88yjkWJwaVKYd9QfTaxcsOxoMNKd7iBr447zCfDV0z1kOF47umv42g==}
@@ -638,6 +804,9 @@ packages:
   arraybuffer.prototype.slice@1.0.2:
     resolution: {integrity: sha512-yMBKppFur/fbHu9/6USUe03bZ4knMYiwFBcyiaXB8Go0qNehwX6inYPzK9U0NeQvGxKthcmHcaR8P5MStSRBAw==}
     engines: {node: '>= 0.4'}
+
+  asap@2.0.6:
+    resolution: {integrity: sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==}
 
   asn1@0.2.6:
     resolution: {integrity: sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==}
@@ -649,11 +818,22 @@ packages:
   assertion-error@1.1.0:
     resolution: {integrity: sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==}
 
+  astral-regex@2.0.0:
+    resolution: {integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==}
+    engines: {node: '>=8'}
+
   async-limiter@1.0.1:
     resolution: {integrity: sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==}
 
+  async@1.5.2:
+    resolution: {integrity: sha512-nSVgobk4rv61R9PUSDtYt7mPVB2olxNR5RWJcAsH676/ef11bUZwvu7+RGYrYauVdDPcO519v68wRhXQtxsV9w==}
+
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+
+  at-least-node@1.0.0:
+    resolution: {integrity: sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==}
+    engines: {node: '>= 4.0.0'}
 
   available-typed-arrays@1.0.5:
     resolution: {integrity: sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==}
@@ -833,6 +1013,15 @@ packages:
     resolution: {integrity: sha512-5IMhi9e1QU76ppa5/ajP1BmMWZ2FHkhAhjeVKQ/EFCgYSEaeVaoGtL7cxJskf9oCCk+XjzaIdc3IuU/dbA/o2A==}
     engines: {node: '>=6.0.0'}
 
+  cbor@8.1.0:
+    resolution: {integrity: sha512-DwGjNW9omn6EwP70aXsn7FQJx5kO12tX0bZkaTjzdVFM6/7nhA4t0EENocKGx6D2Bch9PE2KzCUf5SceBdeijg==}
+    engines: {node: '>=12.19'}
+
+  chai-as-promised@7.1.2:
+    resolution: {integrity: sha512-aBDHZxRzYnUYuIAIPBH2s511DjlKPzXNlXSGFC8CwmroWQLfrW0LtE1nK3MAwwNhJPa9raEjNCmRoFpG0Hurdw==}
+    peerDependencies:
+      chai: '>= 2.1.2 < 6'
+
   chai-bn@0.2.2:
     resolution: {integrity: sha512-MzjelH0p8vWn65QKmEq/DLBG1Hle4WeyqT79ANhXZhn/UxRWO0OogkAxi5oGGtfzwU9bZR8mvbvYdoqNVWQwFg==}
     peerDependencies:
@@ -853,6 +1042,9 @@ packages:
 
   change-case@3.0.2:
     resolution: {integrity: sha512-Mww+SLF6MZ0U6kdg11algyKd5BARbyM4TbFBepwowYSR5ClfQGCGtxNXgykpN0uF/bstWeaGDT4JWaDh8zWAHA==}
+
+  charenc@0.0.2:
+    resolution: {integrity: sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==}
 
   check-error@1.0.3:
     resolution: {integrity: sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==}
@@ -893,6 +1085,10 @@ packages:
     resolution: {integrity: sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==}
     engines: {node: '>=6'}
 
+  cli-table3@0.5.1:
+    resolution: {integrity: sha512-7Qg2Jrep1S/+Q3EceiZtQcDPWxhAvBw+ERf1162v4sikJrvojMHFqXt8QIVha8UlH9rgU0BeWPytZ9/TzYqlUw==}
+    engines: {node: '>=6'}
+
   cliui@3.2.0:
     resolution: {integrity: sha512-0yayqDxWQbqk3ojkYqUKqaAQ6AfNKeKWRNA8kR0WXzAsdHpP4BIaOmMAG87JGuO6qcobyW4GjxHd9PmhEd+T9w==}
 
@@ -930,11 +1126,23 @@ packages:
   command-exists@1.2.9:
     resolution: {integrity: sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w==}
 
+  command-line-args@5.2.1:
+    resolution: {integrity: sha512-H4UfQhZyakIjC74I9d34fGYDwk3XpSr17QhEd0Q3I9Xq1CETHo4Hcuo87WyWHpAF1aSLjLRf5lD9ZGX2qStUvg==}
+    engines: {node: '>=4.0.0'}
+
+  command-line-usage@6.1.3:
+    resolution: {integrity: sha512-sH5ZSPr+7UStsloltmDh7Ce5fb8XPlHyoPzTpyyMuYCtervL65+ubVZ6Q61cFtFl62UyJlc8/JwERRbAFPUqgw==}
+    engines: {node: '>=8.0.0'}
+
   commander@3.0.2:
     resolution: {integrity: sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow==}
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
+  concat-stream@1.6.2:
+    resolution: {integrity: sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==}
+    engines: {'0': node >= 0.8}
 
   constant-case@2.0.0:
     resolution: {integrity: sha512-eS0N9WwmjTqrOmR3o83F5vW8Z+9R1HnVz3xmzT2PMFug9ly+Au/fxRWlEBSb6LcZwspSsEn9Xs1uw9YgzAg1EQ==}
@@ -988,6 +1196,9 @@ packages:
   cross-fetch@4.0.0:
     resolution: {integrity: sha512-e4a5N8lVvuLgAWgnCrLr2PP0YyDOTHa9H/Rj54dirp61qXnNq46m82bRhNqIA5VccJtWBvPTFRV3TtvHUKPB1g==}
 
+  crypt@0.0.2:
+    resolution: {integrity: sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==}
+
   crypto-addr-codec@0.1.8:
     resolution: {integrity: sha512-GqAK90iLLgP3FvhNmHbpT3wR6dEdaM8hZyZtLX29SPardh3OA13RFLHDR6sntGCgRWOfiHqW6sIyohpNqOtV/g==}
 
@@ -1006,6 +1217,9 @@ packages:
     resolution: {integrity: sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==}
     engines: {node: '>=0.10'}
 
+  death@1.1.0:
+    resolution: {integrity: sha512-vsV6S4KVHvTGxbEcij7hkWRv0It+sGGWVOM67dQde/o5Xjnr+KmLjxWJii2uEObIrt1CcM9w0Yaovx+iOlIL+w==}
+
   debug@2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
     peerDependencies:
@@ -1016,6 +1230,15 @@ packages:
 
   debug@4.3.4:
     resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  debug@4.3.7:
+    resolution: {integrity: sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==}
     engines: {node: '>=6.0'}
     peerDependencies:
       supports-color: '*'
@@ -1046,6 +1269,13 @@ packages:
   deep-eql@4.1.4:
     resolution: {integrity: sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==}
     engines: {node: '>=6'}
+
+  deep-extend@0.6.0:
+    resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
+    engines: {node: '>=4.0.0'}
+
+  deep-is@0.1.4:
+    resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
   defer-to-connect@2.0.1:
     resolution: {integrity: sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==}
@@ -1079,9 +1309,16 @@ packages:
     resolution: {integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==}
     engines: {node: '>=0.3.1'}
 
-  diff@5.0.0:
-    resolution: {integrity: sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==}
+  diff@5.2.0:
+    resolution: {integrity: sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==}
     engines: {node: '>=0.3.1'}
+
+  difflib@0.2.4:
+    resolution: {integrity: sha512-9YVwmMb0wQHQNr5J9m6BSj6fk4pfGITGQOOs+D9Fl+INODWFOfvhIU1hNv6GgR1RBoC/9NJcwu77zShxV0kT7w==}
+
+  dir-glob@3.0.1:
+    resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
+    engines: {node: '>=8'}
 
   dom-serializer@2.0.0:
     resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
@@ -1180,9 +1417,32 @@ packages:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
 
+  escodegen@1.8.1:
+    resolution: {integrity: sha512-yhi5S+mNTOuRvyW4gWlg5W1byMaQGWWSYHXsuFZ7GBo7tpyOwi2EdzMP/QWxh9hwkD2m+wDVHJsxhRIj+v/b/A==}
+    engines: {node: '>=0.12.0'}
+    hasBin: true
+
   esniff@2.0.1:
     resolution: {integrity: sha512-kTUIGKQ/mDPFoJ0oVfcmyJn4iBDRptjNVIzwIFR7tqWXdVI9xfA2RMwY/gbSpJG3lkdWNEjLap/NqVHZiJsdfg==}
     engines: {node: '>=0.10'}
+
+  esprima@2.7.3:
+    resolution: {integrity: sha512-OarPfz0lFCiW4/AV2Oy1Rp9qu0iusTKqykwTspGCZtPxmF81JR4MmIebvF1F9+UOKth2ZubLQ4XGGaU+hSn99A==}
+    engines: {node: '>=0.10.0'}
+    hasBin: true
+
+  esprima@4.0.1:
+    resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
+    engines: {node: '>=4'}
+    hasBin: true
+
+  estraverse@1.9.3:
+    resolution: {integrity: sha512-25w1fMXQrGdoquWnScXZGckOv+Wes+JDnuN/+7ex3SauFRS72r2lFDec0EKPt2YD1wUJ/IrfEex+9yp4hfSOJA==}
+    engines: {node: '>=0.10.0'}
+
+  esutils@2.0.3:
+    resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
+    engines: {node: '>=0.10.0'}
 
   etag@1.8.1:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
@@ -1190,6 +1450,14 @@ packages:
 
   eth-ens-namehash@2.0.8:
     resolution: {integrity: sha512-VWEI1+KJfz4Km//dadyvBBoBeSQ0MHTXPvr8UIXiLW6IanxvAV+DmlZAijZwAyggqGUfwQBeHf7tc9wzc1piSw==}
+
+  eth-gas-reporter@0.2.27:
+    resolution: {integrity: sha512-femhvoAM7wL0GcI8ozTdxfuBtBFJ9qsyIAsmKVjlWAHUbdnnXHt+lKzz/kmldM5lA9jLuNHGwuIxorNpLbR1Zw==}
+    peerDependencies:
+      '@codechecks/client': ^0.1.0
+    peerDependenciesMeta:
+      '@codechecks/client':
+        optional: true
 
   eth-lib@0.1.29:
     resolution: {integrity: sha512-bfttrr3/7gG4E02HoWTDUcDDslN003OlOoBxk9virpAZQ1ja/jDgwkWB8QfJF7ojuEowrqy+lzp9VcJG7/k5bQ==}
@@ -1274,16 +1542,35 @@ packages:
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
+  fast-glob@3.3.2:
+    resolution: {integrity: sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==}
+    engines: {node: '>=8.6.0'}
+
   fast-json-stable-stringify@2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
 
-  fhenix-hardhat-plugin@0.2.1:
-    resolution: {integrity: sha512-E10QnEBjTaFLYCOfa8tzd2yxBeghm/IlLiMztSFYciBH+jX5ofCIfd4Dv5e4VayqAVncFwi6KB2auLi3UXJ5HA==}
+  fast-levenshtein@2.0.6:
+    resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+
+  fast-uri@3.0.3:
+    resolution: {integrity: sha512-aLrHthzCjH5He4Z2H9YZ+v6Ujb9ocRuW6ZzkJQOrTxleEijANq4v1TsaPaVG1PZcuurEzrLcWRyYBYXD5cEiaw==}
+
+  fastq@1.17.1:
+    resolution: {integrity: sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==}
+
+  fhenix-hardhat-docker@0.3.0-alpha.2:
+    resolution: {integrity: sha512-mAV15OcYJEjDpOCufZurNv7y/0LMsGA6IOhcSlH/77NIl6ZBT6mUyWKlZNyXpuh+/el/i5xCUQfRnRAh55FVTg==}
     peerDependencies:
       hardhat: ^2.0.0
 
-  fhenixjs@0.2.1:
-    resolution: {integrity: sha512-OJmZrLCouotywnn6HbNeSvPYGZ3awQ4QgRcb8lAoJjpUixscsQl3e3SqlEzZCvgoyoXNeg2f+8n4CZvQBqqJ5Q==}
+  fhenix-hardhat-plugin@0.3.0-alpha.2:
+    resolution: {integrity: sha512-/9tmEfZab2G65kQvitR1shH9KUzmMNXN+sXtX9jDSI8QiIzrb2d7jRJP7B5B0ps8/arfPsegO3jm4mDj6CpOEg==}
+    peerDependencies:
+      hardhat: ^2.0.0
+
+  fhenixjs@0.4.0-alpha.6:
+    resolution: {integrity: sha512-pFXw0nEsK9nf3dMUz+N2fMbHiknDlllEiKJpTqNKNwBuJSmkw3aBOGJ6zVZcWfKxL0/5Pv+nfDfcAmyRwUQNnA==}
+    engines: {node: '>=20.0.0'}
 
   fill-range@7.0.1:
     resolution: {integrity: sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==}
@@ -1296,6 +1583,10 @@ packages:
   finalhandler@1.2.0:
     resolution: {integrity: sha512-5uXcUVftlQMFnWC9qu/svkWv3GTd2PfUhK/3PLkYNAe7FbqJMt3515HaxE6eRL74GdsriiwujiawdaB1BpEISg==}
     engines: {node: '>= 0.8'}
+
+  find-replace@3.0.0:
+    resolution: {integrity: sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==}
+    engines: {node: '>=4.0.0'}
 
   find-up@1.1.2:
     resolution: {integrity: sha512-jvElSjyuo4EMQGoTwo1uJU5pQMwTW5lS1x05zzfJuTIyLR3zwO27LYrxNg+dlvKpGOuGy/MzBdXh80g0ve5+HA==}
@@ -1377,8 +1668,15 @@ packages:
     resolution: {integrity: sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==}
     engines: {node: '>=6 <7 || >=8'}
 
+  fs-extra@9.1.0:
+    resolution: {integrity: sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==}
+    engines: {node: '>=10'}
+
   fs-minipass@1.2.7:
     resolution: {integrity: sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==}
+
+  fs-readdir-recursive@1.1.0:
+    resolution: {integrity: sha512-GNanXlVr2pf02+sPN40XN8HG+ePaNcvM0q5mZBd668Obwb0yD5GiUbZOFgwn8kGMY6I3mdyDJzieUy3PTYyTRA==}
 
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
@@ -1420,6 +1718,10 @@ packages:
   get-intrinsic@1.2.2:
     resolution: {integrity: sha512-0gSo4ml/0j98Y3lngkFEot/zhiCeWsbYIlZ+uZOVgzLyLaUw7wxUL+nCTP0XJvJg1AXulJRI3UJi8GsbDuxdGA==}
 
+  get-port@3.2.0:
+    resolution: {integrity: sha512-x5UJKlgeUiNT8nyo/AcnwLnZuZNcSjSw0kogRB+Whd1fjjFq4B1hySFxSFWWSn4mIBzg3sRNUDFYc4g5gjPoLg==}
+    engines: {node: '>=4'}
+
   get-stream@5.2.0:
     resolution: {integrity: sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==}
     engines: {node: '>=8'}
@@ -1435,15 +1737,41 @@ packages:
   getpass@0.1.7:
     resolution: {integrity: sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==}
 
+  ghost-testrpc@0.0.2:
+    resolution: {integrity: sha512-i08dAEgJ2g8z5buJIrCTduwPIhih3DP+hOCTyyryikfV8T0bNvHnGXO67i0DD1H4GBDETTclPy9njZbfluQYrQ==}
+    hasBin: true
+
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
+
+  glob@5.0.15:
+    resolution: {integrity: sha512-c9IPMazfRITpmAAKi22dK1VKxGDX9ehhqfABDriL/lzO92xcUKEJPQHrVA/2YHSNFB4iFlykVmWvwo48nr3OxA==}
+    deprecated: Glob versions prior to v9 are no longer supported
+
+  glob@7.1.7:
+    resolution: {integrity: sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==}
+    deprecated: Glob versions prior to v9 are no longer supported
 
   glob@7.2.0:
     resolution: {integrity: sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==}
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
+    deprecated: Glob versions prior to v9 are no longer supported
+
+  glob@8.1.0:
+    resolution: {integrity: sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==}
+    engines: {node: '>=12'}
+    deprecated: Glob versions prior to v9 are no longer supported
+
+  global-modules@2.0.0:
+    resolution: {integrity: sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==}
+    engines: {node: '>=6'}
+
+  global-prefix@3.0.0:
+    resolution: {integrity: sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==}
+    engines: {node: '>=6'}
 
   global@4.4.0:
     resolution: {integrity: sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==}
@@ -1451,6 +1779,10 @@ packages:
   globalthis@1.0.3:
     resolution: {integrity: sha512-sFdI5LyBiNTHjRd7cGPWapiHWMOXKyuBNX/cWJ3NfzrZQVa8GI/8cofCl74AOVqq9W5kNmguTIzJ/1s2gyI9wA==}
     engines: {node: '>= 0.4'}
+
+  globby@10.0.2:
+    resolution: {integrity: sha512-7dUi7RvCoT/xast/o/dLN53oqND4yk0nsHkhRgn9w65C4PofCLOoJ39iSOg+qVDdWQPIEj+eszMHQ+aLVwwQSg==}
+    engines: {node: '>=8'}
 
   gopd@1.0.1:
     resolution: {integrity: sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==}
@@ -1485,6 +1817,11 @@ packages:
     peerDependencies:
       hardhat: ^2.3.0
 
+  hardhat-gas-reporter@1.0.10:
+    resolution: {integrity: sha512-02N4+So/fZrzJ88ci54GqwVA3Zrf0C9duuTyGt0CFRIh/CdNwbnTgkXkRfojOMLBQ+6t+lBIkgbsOtqMvNwikA==}
+    peerDependencies:
+      hardhat: ^2.0.2
+
   hardhat@2.19.3:
     resolution: {integrity: sha512-zUvfILiu1O7W1a+t5E1nCJ6z1danRLNizQkSEQCCgDYcRx13AGXtH1MVZajKmdLmXIjKAPReTp/8JQQ4ZHaX3g==}
     hasBin: true
@@ -1499,6 +1836,10 @@ packages:
 
   has-bigints@1.0.2:
     resolution: {integrity: sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==}
+
+  has-flag@1.0.0:
+    resolution: {integrity: sha512-DyYHfIYwAJmjAjSSPKANxI8bFY9YtFrgkAfinBojQ8YJTOuOuav64tMUJv584SES4xl74PmuaevIyaLESHdTAA==}
+    engines: {node: '>=0.10.0'}
 
   has-flag@3.0.0:
     resolution: {integrity: sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==}
@@ -1548,6 +1889,9 @@ packages:
   header-case@1.0.1:
     resolution: {integrity: sha512-i0q9mkOeSuhXw6bGgiQCCBgY/jlZuV/7dZXyZ9c6LcBrqwvT8eT719E9uxE5LiZftdl+z81Ugbg/VvXV4OJOeQ==}
 
+  heap@0.2.7:
+    resolution: {integrity: sha512-2bsegYkkHO+h/9MGbn6KWcE45cHZgPANo5LXF7EvWdT0yT2EguSVO1nDgU5c8+ZOPwp2vMNa7YFsJhVcDR9Sdg==}
+
   highlight.js@10.7.3:
     resolution: {integrity: sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==}
 
@@ -1563,6 +1907,10 @@ packages:
   htmlparser2@8.0.2:
     resolution: {integrity: sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==}
 
+  http-basic@8.1.3:
+    resolution: {integrity: sha512-/EcDMwJZh3mABI2NhGfHOGOeOZITqfkEO4p/xK+l3NpyncIHUQBoMvCSF/b5GqvKtySC2srL/GGG3+EtlqlmCw==}
+    engines: {node: '>=6.0.0'}
+
   http-cache-semantics@4.1.1:
     resolution: {integrity: sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==}
 
@@ -1572,6 +1920,9 @@ packages:
 
   http-https@1.0.0:
     resolution: {integrity: sha512-o0PWwVCSp3O0wS6FvNr6xfBCHgt0m1tvPLFOCc2iFDKTRAXhB7m8klDf7ErowFH8POa6dVdGatKU5I1YYwzUyg==}
+
+  http-response-object@3.0.2:
+    resolution: {integrity: sha512-bqX0XTF6fnXSQcEJ2Iuyr75yVakyjIDCqroJQ/aHfSdlM743Cwqoi2nDYMzLGWUcuTWGWy8AAvOKXTfiv6q9RA==}
 
   http-signature@1.2.0:
     resolution: {integrity: sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==}
@@ -1600,6 +1951,10 @@ packages:
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
+  ignore@5.3.2:
+    resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
+    engines: {node: '>= 4'}
+
   immutable@4.3.0:
     resolution: {integrity: sha512-0AOCmOip+xgJwEVTQj1EfiDDOkPmuyllDuTuEX+DDXUgapLAsBIfkg3sxCYyCEA8mQqZrrxPUGjcOQ2JS3WLkg==}
 
@@ -1613,9 +1968,16 @@ packages:
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
+  ini@1.3.8:
+    resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
+
   internal-slot@1.0.5:
     resolution: {integrity: sha512-Y+R5hJrzs52QCG2laLn4udYVnxsfny9CpOhNhUvk/SSSVyF6T27FzRbF0sroPidSu3X8oEAkOn2K804mjpt6UQ==}
     engines: {node: '>= 0.4'}
+
+  interpret@1.4.0:
+    resolution: {integrity: sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==}
+    engines: {node: '>= 0.10'}
 
   invert-kv@1.0.0:
     resolution: {integrity: sha512-xgs2NH9AE66ucSq4cNG1nhSFghr5l6tdL15Pk+jl46bmmBapgoaY/AacXyaDznAqmGL99TiLSQgO/XazFSKYeQ==}
@@ -1668,6 +2030,10 @@ packages:
   is-fullwidth-code-point@1.0.0:
     resolution: {integrity: sha512-1pqUqRjkhPJ9miNq9SwMfdvi6lBJcd6eFxvfaivQhaH3SgisfiuudvFntdKOmxuee/77l+FPjKrQjWvmPjWrRw==}
     engines: {node: '>=0.10.0'}
+
+  is-fullwidth-code-point@2.0.0:
+    resolution: {integrity: sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==}
+    engines: {node: '>=4'}
 
   is-fullwidth-code-point@3.0.0:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
@@ -1742,8 +2108,14 @@ packages:
   is-weakref@1.0.2:
     resolution: {integrity: sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==}
 
+  isarray@1.0.0:
+    resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
+
   isarray@2.0.5:
     resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
+
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
   isstream@0.1.2:
     resolution: {integrity: sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==}
@@ -1760,6 +2132,10 @@ packages:
   js-sha3@0.8.0:
     resolution: {integrity: sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==}
 
+  js-yaml@3.14.1:
+    resolution: {integrity: sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==}
+    hasBin: true
+
   js-yaml@4.1.0:
     resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
     hasBin: true
@@ -1773,6 +2149,9 @@ packages:
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
 
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
   json-schema@0.4.0:
     resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
 
@@ -1785,6 +2164,12 @@ packages:
   jsonfile@4.0.0:
     resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
 
+  jsonfile@6.1.0:
+    resolution: {integrity: sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==}
+
+  jsonschema@1.4.1:
+    resolution: {integrity: sha512-S6cATIPVv1z0IlxdN+zUk5EPjkGCdnhN4wVSBlvoUO1tOLJootbo9CquNJmbIh4yikWHiUedhRYrNPn1arpEmQ==}
+
   jsprim@1.4.2:
     resolution: {integrity: sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==}
     engines: {node: '>=0.6.0'}
@@ -1795,6 +2180,10 @@ packages:
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
+  kind-of@6.0.3:
+    resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
+    engines: {node: '>=0.10.0'}
 
   klaw@1.3.1:
     resolution: {integrity: sha512-TED5xi9gGQjGpNnvRWknrwAB1eL5GciPfVFOt3Vk1OJCVDQbzuSfrF3hkUQKlsgKrG1F+0t5W0m+Fje1jIt8rw==}
@@ -1815,6 +2204,10 @@ packages:
     resolution: {integrity: sha512-ypf0jjAk2BWI33yzEaaotpq7fkOPALKAgDBxggO6Q9HGX2MRXn0wbP1Jn/tJv1gtL867+YOjOB49WaUF3UoJNQ==}
     engines: {node: '>=12'}
 
+  levn@0.3.0:
+    resolution: {integrity: sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==}
+    engines: {node: '>= 0.8.0'}
+
   load-json-file@1.1.0:
     resolution: {integrity: sha512-cy7ZdNRXdablkXYNI049pthVeXFurRyb9+hA/dZzerZ0pGTx42z+y+ssxBaVV2l70t1muq5IdKhn4UtcoGUY9A==}
     engines: {node: '>=0.10.0'}
@@ -1834,6 +2227,12 @@ packages:
   lodash.assign@4.2.0:
     resolution: {integrity: sha512-hFuH8TY+Yji7Eja3mGiuAxBqLagejScbG8GbG0j6o9vzn0YL14My+ktnqtZgFTosKymC9/44wP6s7xyuLfnClw==}
 
+  lodash.camelcase@4.3.0:
+    resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
+
+  lodash.clonedeep@4.5.0:
+    resolution: {integrity: sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==}
+
   lodash.flatten@4.4.0:
     resolution: {integrity: sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==}
 
@@ -1842,6 +2241,9 @@ packages:
 
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
+
+  lodash.truncate@4.4.2:
+    resolution: {integrity: sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==}
 
   lodash@4.17.21:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
@@ -1876,6 +2278,9 @@ packages:
   make-error@1.3.6:
     resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
 
+  markdown-table@1.1.3:
+    resolution: {integrity: sha512-1RUZVgQlpJSPWYbFSpmudq5nHY1doEIv89gBtF0s4gW1GF2XorxcA/70M5vq7rLv0a6mhOUccRsqkwhwLCIQ2Q==}
+
   mcl-wasm@0.7.9:
     resolution: {integrity: sha512-iJIUcQWA88IJB/5L15GnJVnSQJmf/YaxxV6zRavv83HILHaJQb6y0iFyDMdDO0gN8X37tdxmAOrH/P8B6RB8sQ==}
     engines: {node: '>=8.9.0'}
@@ -1897,6 +2302,10 @@ packages:
 
   merge-descriptors@1.0.1:
     resolution: {integrity: sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w==}
+
+  merge2@1.4.1:
+    resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
+    engines: {node: '>= 8'}
 
   methods@1.1.2:
     resolution: {integrity: sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==}
@@ -1942,8 +2351,8 @@ packages:
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
 
-  minimatch@5.0.1:
-    resolution: {integrity: sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==}
+  minimatch@5.1.6:
+    resolution: {integrity: sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==}
     engines: {node: '>=10'}
 
   minimist@1.2.8:
@@ -1964,6 +2373,11 @@ packages:
     resolution: {integrity: sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==}
     hasBin: true
 
+  mkdirp@1.0.4:
+    resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   mkdirp@3.0.1:
     resolution: {integrity: sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==}
     engines: {node: '>=10'}
@@ -1972,8 +2386,8 @@ packages:
   mnemonist@0.38.5:
     resolution: {integrity: sha512-bZTFT5rrPKtPJxj8KSV0WkPyNxl72vQepqqVUAW2ARUpUSF2qXMB6jZj7hW5/k7C1rtpzqbD/IIbJwLXUjCHeg==}
 
-  mocha@10.1.0:
-    resolution: {integrity: sha512-vUF7IYxEoN7XhQpFLxQAEMtE4W91acW4B6En9l97MwE9stL1A9gusXfoHZCLVHDUJ/7V5+lbCM6yMqzo5vNymg==}
+  mocha@10.8.2:
+    resolution: {integrity: sha512-VZlYo/WE8t1tstuRmqgeyBgCbJc/lEdopaa+axcKzTBJ+UIdlAB9XnmvTCAH4pwR4ElNInaedhEBmZD8iCSVEg==}
     engines: {node: '>= 14.0.0'}
     hasBin: true
 
@@ -2018,11 +2432,6 @@ packages:
   nano-json-stream-parser@0.1.2:
     resolution: {integrity: sha512-9MqxMH/BSJC7dnLsEMPyfN5Dvoo49IsPFYMcHw3Bcfc2kN0lpHRBSzlMSVx4HGyJ7s9B31CyBTVehWJoQ8Ctew==}
 
-  nanoid@3.3.3:
-    resolution: {integrity: sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w==}
-    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
-    hasBin: true
-
   napi-macros@2.2.2:
     resolution: {integrity: sha512-hmEVtAGYzVQpCKdbQea4skABsdXW4RUh5t5mJ2zzqowJS2OyXZTU1KhDVFhx+NlWZ4ap9mqR9TcDO3LTTttd+g==}
 
@@ -2042,6 +2451,9 @@ packages:
   node-addon-api@2.0.2:
     resolution: {integrity: sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA==}
 
+  node-emoji@1.11.0:
+    resolution: {integrity: sha512-wo2DpQkQp7Sjm2A0cq+sN7EHKO6Sl0ctXeBdFZrL9T9+UywORbufTcTZxom8YqpLQt/FqNMUkOpkZrJVYSKD3A==}
+
   node-fetch@2.7.0:
     resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
     engines: {node: 4.x || >=6.0.0}
@@ -2055,12 +2467,17 @@ packages:
     resolution: {integrity: sha512-NTZVKn9IylLwUzaKjkas1e4u2DLNcV4rdYagA4PWdPwW87Bi7z+BznyKSRwS/761tV/lzCGXplWsiaMjLqP2zQ==}
     hasBin: true
 
-  node-tfhe@0.6.4:
-    resolution: {integrity: sha512-V/SJjc5GPKIB/KcNGEFSDDQelIKvFIFiCgefeDARgxOnN69fyB+omV4e4j3tMDEz6aN7xRd/NqqQ0im17emXeA==}
-
   nofilter@1.0.4:
     resolution: {integrity: sha512-N8lidFp+fCz+TD51+haYdbDGrcBWwuHX40F5+z0qkUjMJ5Tp+rdSuAkMJ9N9eoolDlEVTf6u5icM+cNKkKW2mA==}
     engines: {node: '>=8'}
+
+  nofilter@3.1.0:
+    resolution: {integrity: sha512-l2NNj07e9afPnhAhvgVrCD/oy2Ai1yfLpuo3EpiO1jFTsB4sFz6oIfAfSZyQzVpkZQ9xS8ZS5g1jCBgq4Hwo0g==}
+    engines: {node: '>=12.19'}
+
+  nopt@3.0.6:
+    resolution: {integrity: sha512-4GUt3kSEYmk4ITxzB/b9vaIDfUVWN/Ml1Fwl11IlnIG2iaJ9O6WXZ9SrYM9NLI8OCBieN2Y8SWC2oJV0RQ7qYg==}
+    hasBin: true
 
   normalize-package-data@2.5.0:
     resolution: {integrity: sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==}
@@ -2114,6 +2531,13 @@ packages:
 
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+
+  optionator@0.8.3:
+    resolution: {integrity: sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==}
+    engines: {node: '>= 0.8.0'}
+
+  ordinal@1.0.3:
+    resolution: {integrity: sha512-cMddMgb2QElm8G7vdaa02jhUNbTSrhsgAGUz1OokD83uJTwSUn+nKoNoKVVaRa08yF6sgfO7Maou1+bgLd9rdQ==}
 
   os-locale@1.4.0:
     resolution: {integrity: sha512-PRT7ZORmwu2MEFt4/fv3Q+mEfN4zetKxufQrkShY2oGvUms9r8otu5HfdyIFHkYXjO7laNsoVGmM2MANfuTA8g==}
@@ -2173,6 +2597,9 @@ packages:
   param-case@2.1.1:
     resolution: {integrity: sha512-eQE845L6ot89sk2N8liD8HAuH4ca6Vvr7VWAWwt7+kvvG5aBcPmmphQ68JsEG2qa9n1TykS2DLeMt363AAH8/w==}
 
+  parse-cache-control@1.0.1:
+    resolution: {integrity: sha512-60zvsJReQPX5/QP0Kzfd/VrpjScIQ7SHBW6bFCYfEP+fp0Eppr1SHhIO5nd1PjZtvclzSzES9D/p5nFJurwfWg==}
+
   parse-headers@2.0.5:
     resolution: {integrity: sha512-ft3iAoLOB/MlwbNXgzy43SWGP6sQki2jQvAyBg/zDFAgr9bfNWZIUj42Kw2eJIl8kEi4PbgE6U1Zau/HwI75HA==}
 
@@ -2222,6 +2649,10 @@ packages:
     resolution: {integrity: sha512-S4eENJz1pkiQn9Znv33Q+deTOKmbl+jj1Fl+qiP/vYezj+S8x+J3Uo0ISrx/QoEvIlOaDWJhPaRd1flJ9HXZqg==}
     engines: {node: '>=0.10.0'}
 
+  path-type@4.0.0:
+    resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
+    engines: {node: '>=8'}
+
   pathval@1.1.1:
     resolution: {integrity: sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==}
 
@@ -2240,6 +2671,10 @@ packages:
     resolution: {integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==}
     engines: {node: '>=0.10.0'}
 
+  pify@4.0.1:
+    resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
+    engines: {node: '>=6'}
+
   pinkie-promise@2.0.1:
     resolution: {integrity: sha512-0Gni6D4UcLTbv9c57DfxDGdr41XfgUjqWZu492f0cIGr16zDU06BWP/RAEvOuo7CQ0CNjHaLlM59YJJFm3NWlw==}
     engines: {node: '>=0.10.0'}
@@ -2248,9 +2683,24 @@ packages:
     resolution: {integrity: sha512-MnUuEycAemtSaeFSjXKW/aroV7akBbY+Sv+RkyqFjgAe73F+MR0TBWKBRDkmfWq/HiFmdavfZ1G7h4SPZXaCSg==}
     engines: {node: '>=0.10.0'}
 
+  prelude-ls@1.1.2:
+    resolution: {integrity: sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==}
+    engines: {node: '>= 0.8.0'}
+
+  prettier@2.8.8:
+    resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
+    engines: {node: '>=10.13.0'}
+    hasBin: true
+
+  process-nextick-args@2.0.1:
+    resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
+
   process@0.11.10:
     resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
     engines: {node: '>= 0.6.0'}
+
+  promise@8.3.0:
+    resolution: {integrity: sha512-rZPNPKTOYVNEEKFaq1HqTgOwZD+4/YHS5ukLzQCypkj+OkYx7iv0mA91lJlpPPZ8vMau3IIGj5Qlwrx+8iiSmg==}
 
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
@@ -2314,6 +2764,9 @@ packages:
     resolution: {integrity: sha512-7BGwRHqt4s/uVbuyoeejRn4YmFnYZiFl4AuaeXHlgZf3sONF0SOGlxs2Pw8g6hCKupo08RafIO5YXFNOKTfwsQ==}
     engines: {node: '>=0.10.0'}
 
+  readable-stream@2.3.8:
+    resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
+
   readable-stream@3.6.2:
     resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
     engines: {node: '>= 6'}
@@ -2322,12 +2775,32 @@ packages:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
 
+  rechoir@0.6.2:
+    resolution: {integrity: sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==}
+    engines: {node: '>= 0.10'}
+
+  recursive-readdir@2.2.3:
+    resolution: {integrity: sha512-8HrF5ZsXk5FAH9dgsx3BlUer73nIhuj+9OrQwEbLTPOBzGkL1lsFCR01am+v+0m2Cmbs1nP12hLDl5FA7EszKA==}
+    engines: {node: '>=6.0.0'}
+
+  reduce-flatten@2.0.0:
+    resolution: {integrity: sha512-EJ4UNY/U1t2P/2k6oqotuX2Cc3T6nxJwsM0N0asT7dhrtH1ltUxDn4NalSYmPE2rCkVpcf/X6R0wDwcFpzhd4w==}
+    engines: {node: '>=6'}
+
   regenerator-runtime@0.14.1:
     resolution: {integrity: sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==}
 
   regexp.prototype.flags@1.5.1:
     resolution: {integrity: sha512-sy6TXMN+hnP/wMy+ISxg3krXx7BAtWVO4UouuCN/ziM9UEne0euamVNafDfvC83bRNr95y0V5iijeDQFUNpvrg==}
     engines: {node: '>= 0.4'}
+
+  req-cwd@2.0.0:
+    resolution: {integrity: sha512-ueoIoLo1OfB6b05COxAA9UpeoscNpYyM+BqYlA7H6LVF4hKGPXQQSSaD2YmvDVJMkk4UDpAHIeU1zG53IqjvlQ==}
+    engines: {node: '>=4'}
+
+  req-from@2.0.0:
+    resolution: {integrity: sha512-LzTfEVDVQHBRfjOUMgNBA+V6DWsSnoeKzf42J7l0xa/B4jyPOuuF5MlNSmomLNGemWTnV2TIdjSSLnEn95fOQA==}
+    engines: {node: '>=4'}
 
   request@2.88.2:
     resolution: {integrity: sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==}
@@ -2352,11 +2825,22 @@ packages:
   resolve-alpn@1.2.1:
     resolution: {integrity: sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==}
 
+  resolve-from@3.0.0:
+    resolution: {integrity: sha512-GnlH6vxLymXJNMBo7XP1fJIzBFbdYt49CuTwmB/6N53t+kMPRMFKz783LlQ4tv28XoQfMWinAJX6WCGf2IlaIw==}
+    engines: {node: '>=4'}
+
+  resolve@1.1.7:
+    resolution: {integrity: sha512-9znBF0vBcaSN3W2j7wKvdERPwqTxSpCq+if5C0WoTCyV9n24rua28jeuQ2pL/HOf+yUe/Mef+H/5p60K0Id3bg==}
+
   resolve@1.17.0:
     resolution: {integrity: sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==}
 
   responselike@2.0.1:
     resolution: {integrity: sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==}
+
+  reusify@1.0.4:
+    resolution: {integrity: sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==}
+    engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
   rimraf@2.7.1:
     resolution: {integrity: sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==}
@@ -2376,6 +2860,9 @@ packages:
   run-parallel-limit@1.1.0:
     resolution: {integrity: sha512-jJA7irRNM91jaKc3Hcl1npHsFLOXOoTkPCUL1JEa1R82O2miplXXRaGdjW/KM/98YQWDhJLiSs793CnXfblJUw==}
 
+  run-parallel@1.2.0:
+    resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+
   rustbn.js@0.2.0:
     resolution: {integrity: sha512-4VlvkRUuCJvr2J6Y0ImW7NvTCriMi7ErOAqWk1y69vAdoNIzCF3yPmgeNzx+RQTLEDFq5sHfscn1MwHxP9hNfA==}
 
@@ -2394,6 +2881,10 @@ packages:
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  sc-istanbul@0.4.6:
+    resolution: {integrity: sha512-qJFF/8tW/zJsbyfh/iT/ZM5QNHE3CXxtLJbZsL+CzdJLBsPD7SedJZoUA4d8iAcN2IoMp/Dx80shOOd2x96X/g==}
+    hasBin: true
 
   scrypt-js@2.0.4:
     resolution: {integrity: sha512-4KsaGcPnuhtCZQCxFxN3GVYIhKFPTdLd8PLC552XwbMndtD0cjRFAhDuuydXQ0h08ZfPgzqe6EKHozpuH74iDw==}
@@ -2425,8 +2916,8 @@ packages:
   sentence-case@2.1.1:
     resolution: {integrity: sha512-ENl7cYHaK/Ktwk5OTD+aDbQ3uC8IByu/6Bkg+HDv8Mm+XnBnppVNalcfJTNsp1ibstKh030/JKQQWglDvtKwEQ==}
 
-  serialize-javascript@6.0.0:
-    resolution: {integrity: sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==}
+  serialize-javascript@6.0.2:
+    resolution: {integrity: sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==}
 
   serve-static@1.15.0:
     resolution: {integrity: sha512-XGuRDNjXUijsUL0vl6nSD7cwURuzEgglbOaFuZM9g3kwDXOWVTck0jLzjPzGD+TazWbboZYu52/9/XPdUgne9g==}
@@ -2460,8 +2951,16 @@ packages:
     resolution: {integrity: sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==}
     hasBin: true
 
+  sha1@1.1.1:
+    resolution: {integrity: sha512-dZBS6OrMjtgVkopB1Gmo4RQCDKiZsqcpAQpkV/aaj+FCrCg8r4I4qMkDPQjBgLIxlmu9k4nUbWq6ohXahOneYA==}
+
   sha3@2.1.4:
     resolution: {integrity: sha512-S8cNxbyb0UGUM2VhRD4Poe5N58gJnJsLJ5vC7FYWGUmGhcsj4++WaIOBFVDxlG0W3To6xBuiRh+i0Qp2oNCOtg==}
+
+  shelljs@0.8.5:
+    resolution: {integrity: sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==}
+    engines: {node: '>=4'}
+    hasBin: true
 
   side-channel@1.0.4:
     resolution: {integrity: sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==}
@@ -2471,6 +2970,14 @@ packages:
 
   simple-get@2.8.2:
     resolution: {integrity: sha512-Ijd/rV5o+mSBBs4F/x9oDPtTx9Zb6X9brmnXvMW4J7IR15ngi9q5xxqWBKU744jTZiaXtxaPL7uHG6vtN8kUkw==}
+
+  slash@3.0.0:
+    resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
+    engines: {node: '>=8'}
+
+  slice-ansi@4.0.0:
+    resolution: {integrity: sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==}
+    engines: {node: '>=10'}
 
   snake-case@2.1.0:
     resolution: {integrity: sha512-FMR5YoPFwOLuh4rRz92dywJjyKYZNLpMn1R5ujVpIYkbA9p01fq8RMg0FkO4M+Yobt4MjHeLTJVm5xFFBHSV2Q==}
@@ -2487,6 +2994,12 @@ packages:
   solidity-ast@0.4.55:
     resolution: {integrity: sha512-qeEU/r/K+V5lrAw8iswf2/yfWAnSGs3WKPHI+zAFKFjX0dIBVXEU/swQ8eJQYHf6PJWUZFO2uWV4V1wEOkeQbA==}
 
+  solidity-coverage@0.8.13:
+    resolution: {integrity: sha512-RiBoI+kF94V3Rv0+iwOj3HQVSqNzA9qm/qDP1ZDXK5IX0Cvho1qiz8hAXTsAo6KOIUeP73jfscq0KlLqVxzGWA==}
+    hasBin: true
+    peerDependencies:
+      hardhat: ^2.11.0
+
   solidity-docgen@0.6.0-beta.36:
     resolution: {integrity: sha512-f/I5G2iJgU1h0XrrjRD0hHMr7C10u276vYvm//rw1TzFcYQ4xTOyAoi9oNAHRU0JU4mY9eTuxdVc2zahdMuhaQ==}
     peerDependencies:
@@ -2494,6 +3007,10 @@ packages:
 
   source-map-support@0.5.21:
     resolution: {integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==}
+
+  source-map@0.2.0:
+    resolution: {integrity: sha512-CBdZ2oa/BHhS4xj5DlhjWNHcan57/5YuvfdLf17iVmIpd9KRm+DFLmC6nBNj+6Ua7Kt3TmOjDpQT1aTYOQtoUA==}
+    engines: {node: '>=0.8.0'}
 
   source-map@0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
@@ -2510,6 +3027,9 @@ packages:
 
   spdx-license-ids@3.0.18:
     resolution: {integrity: sha512-xxRs31BqRYHwiMzudOrpSiHtZ8i/GeionCBDSilhYRj+9gIcI8wCZTlXZKu9vZIVqViP3dcp9qE5G6AlIaD+TQ==}
+
+  sprintf-js@1.0.3:
+    resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
 
   sshpk@1.18.0:
     resolution: {integrity: sha512-2p2KJZTSqQ/I3+HX42EpYOa2l3f8Erv8MWKsy2I9uf4wA7yFIkXRffYdsx86y6z4vHtV8u7g+pPlr8/4ouAxsQ==}
@@ -2532,9 +3052,16 @@ packages:
     resolution: {integrity: sha512-R3f198pcvnB+5IpnBlRkphuE9n46WyVl8I39W/ZUTZLz4nqSP/oLYUrcnJrw462Ds8he4YKMov2efsTIw1BDGQ==}
     engines: {node: '>=0.10.0'}
 
+  string-format@2.0.0:
+    resolution: {integrity: sha512-bbEs3scLeYNXLecRRuk6uJxdXUSj6le/8rNPHChIJTn2V79aXVTR1EH2OH5zLKKoz0V02fOUKZZcw01pLUShZA==}
+
   string-width@1.0.2:
     resolution: {integrity: sha512-0XsVpQLnVCXHJfyEs8tC0zpTVIr5PKKsQtkT29IwupnPTjtPmQ3xT/4yCREF9hYkV/3M3kzcUTSAZT6a6h81tw==}
     engines: {node: '>=0.10.0'}
+
+  string-width@2.1.1:
+    resolution: {integrity: sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==}
+    engines: {node: '>=4'}
 
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
@@ -2549,6 +3076,9 @@ packages:
 
   string.prototype.trimstart@1.0.7:
     resolution: {integrity: sha512-NGhtDFu3jCEm7B4Fy0DpLewdJQOZcQ0rGbwQ/+stjnrp2i+rlKeCvos9hOIeCmqwratM47OBxY7uFZzjxHXmrg==}
+
+  string_decoder@1.1.1:
+    resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
 
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
@@ -2581,6 +3111,10 @@ packages:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
 
+  supports-color@3.2.3:
+    resolution: {integrity: sha512-Jds2VIYDrlp5ui7t8abHN2bjAu4LV/q4N2KivFPpGH0lrka0BMq/33AmECUXlKPcHigkNaqfXRENFju+rlcy+A==}
+    engines: {node: '>=0.8.0'}
+
   supports-color@5.5.0:
     resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}
     engines: {node: '>=4'}
@@ -2599,6 +3133,21 @@ packages:
   swarm-js@0.1.42:
     resolution: {integrity: sha512-BV7c/dVlA3R6ya1lMlSSNPLYrntt0LUq4YMgy3iwpCIc6rZnS5W2wUoctarZ5pXlpKtxDDf9hNziEkcfrxdhqQ==}
 
+  sync-request@6.1.0:
+    resolution: {integrity: sha512-8fjNkrNlNCrVc/av+Jn+xxqfCjYaBoHqCsDz6mt030UMxJGr+GSfCV1dQt2gRtlL63+VPidwDVLr7V2OcTSdRw==}
+    engines: {node: '>=8.0.0'}
+
+  sync-rpc@1.3.6:
+    resolution: {integrity: sha512-J8jTXuZzRlvU7HemDgHi3pGnh/rkoqR/OZSjhTyyZrEkkYQbk7Z33AXp37mkPfPpfdOuj7Ex3H/TJM1z48uPQw==}
+
+  table-layout@1.0.2:
+    resolution: {integrity: sha512-qd/R7n5rQTRFi+Zf2sk5XVVd9UQl6ZkduPFC3S7WEGJAmetDTjY3qPN50eSKzwuzEyQKy5TN2TiZdkIjos2L6A==}
+    engines: {node: '>=8.0.0'}
+
+  table@6.8.2:
+    resolution: {integrity: sha512-w2sfv80nrAh2VCbqR5AK27wswXhqcck2AhfnNW76beQXskGZ1V12GwS//yYVa3d3fcvAip2OUnbDAjW2k3v9fA==}
+    engines: {node: '>=10.0.0'}
+
   tar@4.4.19:
     resolution: {integrity: sha512-a20gEsvHnWe0ygBY8JbxoM4w3SJdhc7ZAuxkLqh+nvNQN2IOt0B5lLgM490X5Hl8FF0dl0tOf2ewFYAlIFgzVA==}
     engines: {node: '>=4.5'}
@@ -2607,8 +3156,9 @@ packages:
     resolution: {integrity: sha512-afH1hO+SQ/VPlmaLUFj2636QMeDvPCeQMc/9RBMW0IfjNe9gFD9Ra3ShqYkB7py0do1ZcCna/9acHyzTJ+GcNA==}
     deprecated: testrpc has been renamed to ganache-cli, please use this package from now on.
 
-  tfhe@0.6.4:
-    resolution: {integrity: sha512-80fP2iJJQXrlhyC81u6/aUWMMMDoOXmlY5uqKka2CEd222xM96+z9+FTZc0MjlrR3U+NHja1WOte+A3nlvZkKw==}
+  then-request@6.0.2:
+    resolution: {integrity: sha512-3ZBiG7JvP3wbDzA9iNY5zJQcHL4jn/0BWtXIkagfz7QgOL/LqjCEOBQuJNZfu0XYnv5JhKh+cDxCPM4ILrqruA==}
+    engines: {node: '>=6.0.0'}
 
   timed-out@4.0.1:
     resolution: {integrity: sha512-G7r3AhovYtr5YKOWQkta8RKAPb+J9IsO4uVmzjl8AZwfhs8UcUwTiD6gcJYSgOtzyjvQKrKYn41syHbUWMkafA==}
@@ -2635,6 +3185,15 @@ packages:
 
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
+  ts-command-line-args@2.5.1:
+    resolution: {integrity: sha512-H69ZwTw3rFHb5WYpQya40YAX2/w7Ut75uUECbgBIsLmM+BNuYnxsltfyyLMxy6sEeKxgijLTnQtLd0nKd6+IYw==}
+    hasBin: true
+
+  ts-essentials@7.0.3:
+    resolution: {integrity: sha512-8+gr5+lqO3G84KdiTSMRLtuyJ+nTBVRKuCrK4lidMPdVeEp0uqC875uE5NMcaA7YYMN7XsNiFQuMvasF8HT/xQ==}
+    peerDependencies:
+      typescript: '>=3.7.0'
 
   ts-node@10.9.2:
     resolution: {integrity: sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==}
@@ -2671,6 +3230,10 @@ packages:
   tweetnacl@1.0.3:
     resolution: {integrity: sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==}
 
+  type-check@0.3.2:
+    resolution: {integrity: sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==}
+    engines: {node: '>= 0.8.0'}
+
   type-detect@4.0.8:
     resolution: {integrity: sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==}
     engines: {node: '>=4'}
@@ -2690,6 +3253,12 @@ packages:
   type@2.7.3:
     resolution: {integrity: sha512-8j+1QmAbPvLZow5Qpi6NCaN8FB60p/6x8/vfNqOk/hC+HuvFZhL4+WfekuhQLiqFZXOgQdrs3B+XxEmCc6b3FQ==}
 
+  typechain@8.3.2:
+    resolution: {integrity: sha512-x/sQYr5w9K7yv3es7jo4KTX05CLxOf7TRWwoHlrjRh8H82G64g+k7VuWPJlgMo6qrjfCulOdfBjiaDtmhFYD/Q==}
+    hasBin: true
+    peerDependencies:
+      typescript: '>=4.3.0'
+
   typed-array-buffer@1.0.0:
     resolution: {integrity: sha512-Y8KTSIglk9OZEr8zywiIHG/kmQ7KWyjseXs1CbSo8vC42w7hg2HgYTxSWwP0+is7bWDc1H+Fo026CpHFwm8tkw==}
     engines: {node: '>= 0.4'}
@@ -2708,10 +3277,21 @@ packages:
   typedarray-to-buffer@3.1.5:
     resolution: {integrity: sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==}
 
+  typedarray@0.0.6:
+    resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
+
   typescript@5.5.4:
     resolution: {integrity: sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  typical@4.0.0:
+    resolution: {integrity: sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw==}
+    engines: {node: '>=8'}
+
+  typical@5.2.0:
+    resolution: {integrity: sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg==}
+    engines: {node: '>=8'}
 
   uglify-js@3.17.4:
     resolution: {integrity: sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==}
@@ -2727,6 +3307,9 @@ packages:
   underscore@1.13.6:
     resolution: {integrity: sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A==}
 
+  undici-types@6.19.8:
+    resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
+
   undici@5.22.1:
     resolution: {integrity: sha512-Ji2IJhFXZY0x/0tVBXeQwgPlLWw13GVzpsWPQ3rV50IFMMof2I55PZZxtm4P6iNq+L5znYN9nSTAq0ZyE6lSJw==}
     engines: {node: '>=14.0'}
@@ -2734,6 +3317,10 @@ packages:
   universalify@0.1.2:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
     engines: {node: '>= 4.0.0'}
+
+  universalify@2.0.1:
+    resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
+    engines: {node: '>= 10.0.0'}
 
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
@@ -2990,16 +3577,28 @@ packages:
     resolution: {integrity: sha512-P5Nra0qjSncduVPEAr7xhoF5guty49ArDTwzJ/yNuPIbZppyRxFQsRCWrocxIY+CnMVG+qfbU2FmDKyvSGClow==}
     engines: {node: '>= 0.4'}
 
+  which@1.3.1:
+    resolution: {integrity: sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==}
+    hasBin: true
+
   window-size@0.2.0:
     resolution: {integrity: sha512-UD7d8HFA2+PZsbKyaOCEy8gMh1oDtHgJh1LfgjQ4zVXmYjAT/kvz3PueITKuqDiIXQe7yzpPnxX3lNc+AhQMyw==}
     engines: {node: '>= 0.10.0'}
     hasBin: true
 
+  word-wrap@1.2.5:
+    resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
+    engines: {node: '>=0.10.0'}
+
   wordwrap@1.0.0:
     resolution: {integrity: sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==}
 
-  workerpool@6.2.1:
-    resolution: {integrity: sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==}
+  wordwrapjs@4.0.1:
+    resolution: {integrity: sha512-kKlNACbvHrkpIw6oPeYDSmdCTu2hdMHoyXLTcUKala++lx5Y+wjJ/e474Jqv5abnVmwxw08DiTuHmw69lJGksA==}
+    engines: {node: '>=8.0.0'}
+
+  workerpool@6.5.1:
+    resolution: {integrity: sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA==}
 
   wrap-ansi@2.1.0:
     resolution: {integrity: sha512-vAaEaDM946gbNpH5pLVNR+vX2ht6n0Bt3GXwVB1AuAqZosOvHNF3P7wDnh8KLkSqgUh0uh77le7Owgoz+Z9XBw==}
@@ -3093,8 +3692,8 @@ packages:
   yargs-parser@2.4.1:
     resolution: {integrity: sha512-9pIKIJhnI5tonzG6OnCFlz/yln8xHYcGl+pn3xR0Vzff0vzN1PbNRaelgfgRUwZ3s4i3jvxT9WhmUGL4whnasA==}
 
-  yargs-parser@20.2.4:
-    resolution: {integrity: sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==}
+  yargs-parser@20.2.9:
+    resolution: {integrity: sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==}
     engines: {node: '>=10'}
 
   yargs-unparser@2.0.0:
@@ -3499,6 +4098,18 @@ snapshots:
 
   '@noble/secp256k1@1.7.1': {}
 
+  '@nodelib/fs.scandir@2.1.5':
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      run-parallel: 1.2.0
+
+  '@nodelib/fs.stat@2.0.5': {}
+
+  '@nodelib/fs.walk@1.2.8':
+    dependencies:
+      '@nodelib/fs.scandir': 2.1.5
+      fastq: 1.17.1
+
   '@nomicfoundation/ethereumjs-block@5.0.2(bufferutil@4.0.8)(utf-8-validate@5.0.10)':
     dependencies:
       '@nomicfoundation/ethereumjs-common': 4.0.2
@@ -3522,7 +4133,7 @@ snapshots:
       '@nomicfoundation/ethereumjs-tx': 5.0.2(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       '@nomicfoundation/ethereumjs-util': 9.0.2
       abstract-level: 1.0.3
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.7(supports-color@8.1.1)
       ethereum-cryptography: 0.1.3
       level: 8.0.0
       lru-cache: 5.1.1
@@ -3555,7 +4166,7 @@ snapshots:
       '@nomicfoundation/ethereumjs-common': 4.0.2
       '@nomicfoundation/ethereumjs-tx': 5.0.2(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       '@nomicfoundation/ethereumjs-util': 9.0.2
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.7(supports-color@8.1.1)
       ethereum-cryptography: 0.1.3
       mcl-wasm: 0.7.9
       rustbn.js: 0.2.0
@@ -3570,7 +4181,7 @@ snapshots:
     dependencies:
       '@nomicfoundation/ethereumjs-common': 4.0.2
       '@nomicfoundation/ethereumjs-rlp': 5.0.2
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.7(supports-color@8.1.1)
       ethereum-cryptography: 0.1.3
       ethers: 5.7.2(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       js-sdsl: 4.4.0
@@ -3616,7 +4227,7 @@ snapshots:
       '@nomicfoundation/ethereumjs-trie': 6.0.2
       '@nomicfoundation/ethereumjs-tx': 5.0.2(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       '@nomicfoundation/ethereumjs-util': 9.0.2
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.7(supports-color@8.1.1)
       ethereum-cryptography: 0.1.3
       mcl-wasm: 0.7.9
       rustbn.js: 0.2.0
@@ -3625,12 +4236,63 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@nomicfoundation/hardhat-ethers@3.0.6(ethers@6.13.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))(hardhat@2.19.3(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@18.15.13)(typescript@5.5.4))(typescript@5.5.4)(utf-8-validate@5.0.10))':
+  '@nomicfoundation/hardhat-chai-matchers@2.0.8(@nomicfoundation/hardhat-ethers@3.0.6(ethers@6.13.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))(hardhat@2.19.3(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@20.17.6)(typescript@5.5.4))(typescript@5.5.4)(utf-8-validate@5.0.10)))(chai@4.4.1)(ethers@6.13.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))(hardhat@2.19.3(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@20.17.6)(typescript@5.5.4))(typescript@5.5.4)(utf-8-validate@5.0.10))':
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      '@nomicfoundation/hardhat-ethers': 3.0.6(ethers@6.13.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))(hardhat@2.19.3(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@20.17.6)(typescript@5.5.4))(typescript@5.5.4)(utf-8-validate@5.0.10))
+      '@types/chai-as-promised': 7.1.8
+      chai: 4.4.1
+      chai-as-promised: 7.1.2(chai@4.4.1)
+      deep-eql: 4.1.4
       ethers: 6.13.1(bufferutil@4.0.8)(utf-8-validate@5.0.10)
-      hardhat: 2.19.3(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@18.15.13)(typescript@5.5.4))(typescript@5.5.4)(utf-8-validate@5.0.10)
+      hardhat: 2.19.3(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@20.17.6)(typescript@5.5.4))(typescript@5.5.4)(utf-8-validate@5.0.10)
+      ordinal: 1.0.3
+
+  '@nomicfoundation/hardhat-ethers@3.0.6(ethers@6.13.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))(hardhat@2.19.3(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@20.17.6)(typescript@5.5.4))(typescript@5.5.4)(utf-8-validate@5.0.10))':
+    dependencies:
+      debug: 4.3.4
+      ethers: 6.13.1(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      hardhat: 2.19.3(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@20.17.6)(typescript@5.5.4))(typescript@5.5.4)(utf-8-validate@5.0.10)
       lodash.isequal: 4.5.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@nomicfoundation/hardhat-network-helpers@1.0.12(hardhat@2.19.3(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@20.17.6)(typescript@5.5.4))(typescript@5.5.4)(utf-8-validate@5.0.10))':
+    dependencies:
+      ethereumjs-util: 7.1.5
+      hardhat: 2.19.3(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@20.17.6)(typescript@5.5.4))(typescript@5.5.4)(utf-8-validate@5.0.10)
+
+  '@nomicfoundation/hardhat-toolbox@4.0.0(uezshn5bctuovpk5pjox5apymi)':
+    dependencies:
+      '@nomicfoundation/hardhat-chai-matchers': 2.0.8(@nomicfoundation/hardhat-ethers@3.0.6(ethers@6.13.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))(hardhat@2.19.3(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@20.17.6)(typescript@5.5.4))(typescript@5.5.4)(utf-8-validate@5.0.10)))(chai@4.4.1)(ethers@6.13.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))(hardhat@2.19.3(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@20.17.6)(typescript@5.5.4))(typescript@5.5.4)(utf-8-validate@5.0.10))
+      '@nomicfoundation/hardhat-ethers': 3.0.6(ethers@6.13.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))(hardhat@2.19.3(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@20.17.6)(typescript@5.5.4))(typescript@5.5.4)(utf-8-validate@5.0.10))
+      '@nomicfoundation/hardhat-network-helpers': 1.0.12(hardhat@2.19.3(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@20.17.6)(typescript@5.5.4))(typescript@5.5.4)(utf-8-validate@5.0.10))
+      '@nomicfoundation/hardhat-verify': 2.0.11(hardhat@2.19.3(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@20.17.6)(typescript@5.5.4))(typescript@5.5.4)(utf-8-validate@5.0.10))
+      '@typechain/ethers-v6': 0.5.1(ethers@6.13.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))(typechain@8.3.2(typescript@5.5.4))(typescript@5.5.4)
+      '@typechain/hardhat': 9.1.0(@typechain/ethers-v6@0.5.1(ethers@6.13.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))(typechain@8.3.2(typescript@5.5.4))(typescript@5.5.4))(ethers@6.13.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))(hardhat@2.19.3(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@20.17.6)(typescript@5.5.4))(typescript@5.5.4)(utf-8-validate@5.0.10))(typechain@8.3.2(typescript@5.5.4))
+      '@types/chai': 4.3.16
+      '@types/mocha': 10.0.9
+      '@types/node': 20.17.6
+      chai: 4.4.1
+      ethers: 6.13.1(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      hardhat: 2.19.3(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@20.17.6)(typescript@5.5.4))(typescript@5.5.4)(utf-8-validate@5.0.10)
+      hardhat-gas-reporter: 1.0.10(bufferutil@4.0.8)(hardhat@2.19.3(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@20.17.6)(typescript@5.5.4))(typescript@5.5.4)(utf-8-validate@5.0.10))(utf-8-validate@5.0.10)
+      solidity-coverage: 0.8.13(hardhat@2.19.3(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@20.17.6)(typescript@5.5.4))(typescript@5.5.4)(utf-8-validate@5.0.10))
+      ts-node: 10.9.2(@types/node@20.17.6)(typescript@5.5.4)
+      typechain: 8.3.2(typescript@5.5.4)
+      typescript: 5.5.4
+
+  '@nomicfoundation/hardhat-verify@2.0.11(hardhat@2.19.3(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@20.17.6)(typescript@5.5.4))(typescript@5.5.4)(utf-8-validate@5.0.10))':
+    dependencies:
+      '@ethersproject/abi': 5.7.0
+      '@ethersproject/address': 5.7.0
+      cbor: 8.1.0
+      chalk: 2.4.2
+      debug: 4.3.7(supports-color@8.1.1)
+      hardhat: 2.19.3(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@20.17.6)(typescript@5.5.4))(typescript@5.5.4)(utf-8-validate@5.0.10)
+      lodash.clonedeep: 4.5.0
+      semver: 6.3.0
+      table: 6.8.2
+      undici: 5.22.1
     transitivePeerDependencies:
       - supports-color
 
@@ -3677,15 +4339,15 @@ snapshots:
       '@nomicfoundation/solidity-analyzer-win32-ia32-msvc': 0.1.1
       '@nomicfoundation/solidity-analyzer-win32-x64-msvc': 0.1.1
 
-  '@nomiclabs/hardhat-truffle5@2.0.7(@nomiclabs/hardhat-web3@2.0.0(hardhat@2.19.3(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@18.15.13)(typescript@5.5.4))(typescript@5.5.4)(utf-8-validate@5.0.10))(web3@1.10.4(bufferutil@4.0.8)(utf-8-validate@5.0.10)))(bufferutil@4.0.8)(hardhat@2.19.3(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@18.15.13)(typescript@5.5.4))(typescript@5.5.4)(utf-8-validate@5.0.10))(utf-8-validate@5.0.10)(web3-core-helpers@1.10.4)(web3-core-promievent@1.10.4)(web3-eth-abi@1.10.4)(web3-utils@1.10.4)(web3@1.10.4(bufferutil@4.0.8)(utf-8-validate@5.0.10))':
+  '@nomiclabs/hardhat-truffle5@2.0.7(@nomiclabs/hardhat-web3@2.0.0(hardhat@2.19.3(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@20.17.6)(typescript@5.5.4))(typescript@5.5.4)(utf-8-validate@5.0.10))(web3@1.10.4(bufferutil@4.0.8)(utf-8-validate@5.0.10)))(bufferutil@4.0.8)(hardhat@2.19.3(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@20.17.6)(typescript@5.5.4))(typescript@5.5.4)(utf-8-validate@5.0.10))(utf-8-validate@5.0.10)(web3-core-helpers@1.10.4)(web3-core-promievent@1.10.4)(web3-eth-abi@1.10.4)(web3-utils@1.10.4)(web3@1.10.4(bufferutil@4.0.8)(utf-8-validate@5.0.10))':
     dependencies:
-      '@nomiclabs/hardhat-web3': 2.0.0(hardhat@2.19.3(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@18.15.13)(typescript@5.5.4))(typescript@5.5.4)(utf-8-validate@5.0.10))(web3@1.10.4(bufferutil@4.0.8)(utf-8-validate@5.0.10))
+      '@nomiclabs/hardhat-web3': 2.0.0(hardhat@2.19.3(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@20.17.6)(typescript@5.5.4))(typescript@5.5.4)(utf-8-validate@5.0.10))(web3@1.10.4(bufferutil@4.0.8)(utf-8-validate@5.0.10))
       '@nomiclabs/truffle-contract': 4.5.10(bufferutil@4.0.8)(utf-8-validate@5.0.10)(web3-core-helpers@1.10.4)(web3-core-promievent@1.10.4)(web3-eth-abi@1.10.4)(web3-utils@1.10.4)(web3@1.10.4(bufferutil@4.0.8)(utf-8-validate@5.0.10))
       '@types/chai': 4.3.16
       chai: 4.4.1
       ethereumjs-util: 7.1.5
       fs-extra: 7.0.1
-      hardhat: 2.19.3(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@18.15.13)(typescript@5.5.4))(typescript@5.5.4)(utf-8-validate@5.0.10)
+      hardhat: 2.19.3(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@20.17.6)(typescript@5.5.4))(typescript@5.5.4)(utf-8-validate@5.0.10)
       web3: 1.10.4(bufferutil@4.0.8)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - bufferutil
@@ -3697,10 +4359,10 @@ snapshots:
       - web3-eth-abi
       - web3-utils
 
-  '@nomiclabs/hardhat-web3@2.0.0(hardhat@2.19.3(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@18.15.13)(typescript@5.5.4))(typescript@5.5.4)(utf-8-validate@5.0.10))(web3@1.10.4(bufferutil@4.0.8)(utf-8-validate@5.0.10))':
+  '@nomiclabs/hardhat-web3@2.0.0(hardhat@2.19.3(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@20.17.6)(typescript@5.5.4))(typescript@5.5.4)(utf-8-validate@5.0.10))(web3@1.10.4(bufferutil@4.0.8)(utf-8-validate@5.0.10))':
     dependencies:
       '@types/bignumber.js': 5.0.0
-      hardhat: 2.19.3(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@18.15.13)(typescript@5.5.4))(typescript@5.5.4)(utf-8-validate@5.0.10)
+      hardhat: 2.19.3(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@20.17.6)(typescript@5.5.4))(typescript@5.5.4)(utf-8-validate@5.0.10)
       web3: 1.10.4(bufferutil@4.0.8)(utf-8-validate@5.0.10)
 
   '@nomiclabs/truffle-contract@4.5.10(bufferutil@4.0.8)(utf-8-validate@5.0.10)(web3-core-helpers@1.10.4)(web3-core-promievent@1.10.4)(web3-eth-abi@1.10.4)(web3-utils@1.10.4)(web3@1.10.4(bufferutil@4.0.8)(utf-8-validate@5.0.10))':
@@ -3829,6 +4491,12 @@ snapshots:
 
   '@sindresorhus/is@4.6.0': {}
 
+  '@solidity-parser/parser@0.14.5':
+    dependencies:
+      antlr4ts: 0.5.0-alpha.4
+
+  '@solidity-parser/parser@0.18.0': {}
+
   '@szmarczak/http-timer@4.0.6':
     dependencies:
       defer-to-connect: 2.0.1
@@ -3852,7 +4520,7 @@ snapshots:
       big.js: 6.2.1
       bn.js: 5.2.1
       cbor: 5.2.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.7(supports-color@8.1.1)
       lodash: 4.17.21
       semver: 7.6.3
       utf8: 3.0.0
@@ -3868,7 +4536,7 @@ snapshots:
   '@truffle/contract-schema@3.4.16':
     dependencies:
       ajv: 6.12.6
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
 
@@ -3881,7 +4549,7 @@ snapshots:
       '@truffle/error': 0.2.2
       '@truffle/interface-adapter': 0.5.37(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       bignumber.js: 7.2.1
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       ethers: 4.0.49
       web3: 1.10.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       web3-core-helpers: 1.10.0
@@ -3900,7 +4568,7 @@ snapshots:
       '@trufflesuite/chromafi': 3.0.0
       bn.js: 5.2.1
       chalk: 2.4.2
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       highlightjs-solidity: 2.0.6
     transitivePeerDependencies:
       - supports-color
@@ -3939,6 +4607,22 @@ snapshots:
 
   '@tsconfig/node16@1.0.4': {}
 
+  '@typechain/ethers-v6@0.5.1(ethers@6.13.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))(typechain@8.3.2(typescript@5.5.4))(typescript@5.5.4)':
+    dependencies:
+      ethers: 6.13.1(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      lodash: 4.17.21
+      ts-essentials: 7.0.3(typescript@5.5.4)
+      typechain: 8.3.2(typescript@5.5.4)
+      typescript: 5.5.4
+
+  '@typechain/hardhat@9.1.0(@typechain/ethers-v6@0.5.1(ethers@6.13.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))(typechain@8.3.2(typescript@5.5.4))(typescript@5.5.4))(ethers@6.13.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))(hardhat@2.19.3(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@20.17.6)(typescript@5.5.4))(typescript@5.5.4)(utf-8-validate@5.0.10))(typechain@8.3.2(typescript@5.5.4))':
+    dependencies:
+      '@typechain/ethers-v6': 0.5.1(ethers@6.13.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))(typechain@8.3.2(typescript@5.5.4))(typescript@5.5.4)
+      ethers: 6.13.1(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      fs-extra: 9.1.0
+      hardhat: 2.19.3(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@20.17.6)(typescript@5.5.4))(typescript@5.5.4)(utf-8-validate@5.0.10)
+      typechain: 8.3.2(typescript@5.5.4)
+
   '@types/bignumber.js@5.0.0':
     dependencies:
       bignumber.js: 9.1.2
@@ -3958,7 +4642,24 @@ snapshots:
       '@types/node': 18.15.13
       '@types/responselike': 1.0.3
 
+  '@types/chai-as-promised@7.1.8':
+    dependencies:
+      '@types/chai': 4.3.16
+
   '@types/chai@4.3.16': {}
+
+  '@types/concat-stream@1.6.1':
+    dependencies:
+      '@types/node': 20.17.6
+
+  '@types/form-data@0.0.33':
+    dependencies:
+      '@types/node': 20.17.6
+
+  '@types/glob@7.2.0':
+    dependencies:
+      '@types/minimatch': 5.1.2
+      '@types/node': 20.17.6
 
   '@types/http-cache-semantics@4.0.4': {}
 
@@ -3968,13 +4669,29 @@ snapshots:
 
   '@types/lru-cache@5.1.1': {}
 
+  '@types/minimatch@5.1.2': {}
+
+  '@types/mocha@10.0.9': {}
+
+  '@types/node@10.17.60': {}
+
   '@types/node@12.20.55': {}
 
   '@types/node@18.15.13': {}
 
+  '@types/node@20.17.6':
+    dependencies:
+      undici-types: 6.19.8
+
+  '@types/node@8.10.66': {}
+
   '@types/pbkdf2@3.1.0':
     dependencies:
       '@types/node': 18.15.13
+
+  '@types/prettier@2.7.3': {}
+
+  '@types/qs@6.9.17': {}
 
   '@types/readable-stream@2.3.15':
     dependencies:
@@ -3988,6 +4705,8 @@ snapshots:
   '@types/secp256k1@4.0.3':
     dependencies:
       '@types/node': 18.15.13
+
+  abbrev@1.0.9: {}
 
   abortcontroller-polyfill@1.7.5: {}
 
@@ -4020,7 +4739,7 @@ snapshots:
 
   agent-base@6.0.2:
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.7(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -4036,9 +4755,17 @@ snapshots:
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
 
-  ansi-colors@3.2.4: {}
+  ajv@8.17.1:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.0.3
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
 
-  ansi-colors@4.1.1: {}
+  amdefine@1.0.1:
+    optional: true
+
+  ansi-colors@3.2.4: {}
 
   ansi-colors@4.1.3: {}
 
@@ -4060,6 +4787,8 @@ snapshots:
     dependencies:
       color-convert: 2.0.1
 
+  antlr4ts@0.5.0-alpha.4: {}
+
   anymatch@3.1.3:
     dependencies:
       normalize-path: 3.0.0
@@ -4067,7 +4796,15 @@ snapshots:
 
   arg@4.1.3: {}
 
+  argparse@1.0.10:
+    dependencies:
+      sprintf-js: 1.0.3
+
   argparse@2.0.1: {}
+
+  array-back@3.1.0: {}
+
+  array-back@4.0.2: {}
 
   array-buffer-byte-length@1.0.0:
     dependencies:
@@ -4075,6 +4812,10 @@ snapshots:
       is-array-buffer: 3.0.2
 
   array-flatten@1.1.1: {}
+
+  array-union@2.1.0: {}
+
+  array-uniq@1.0.3: {}
 
   array.prototype.findlast@1.2.3:
     dependencies:
@@ -4094,6 +4835,8 @@ snapshots:
       is-array-buffer: 3.0.2
       is-shared-array-buffer: 1.0.2
 
+  asap@2.0.6: {}
+
   asn1@0.2.6:
     dependencies:
       safer-buffer: 2.1.2
@@ -4102,9 +4845,15 @@ snapshots:
 
   assertion-error@1.1.0: {}
 
+  astral-regex@2.0.0: {}
+
   async-limiter@1.0.1: {}
 
+  async@1.5.2: {}
+
   asynckit@0.4.0: {}
+
+  at-least-node@1.0.0: {}
 
   available-typed-arrays@1.0.5: {}
 
@@ -4295,6 +5044,15 @@ snapshots:
       bignumber.js: 9.1.2
       nofilter: 1.0.4
 
+  cbor@8.1.0:
+    dependencies:
+      nofilter: 3.1.0
+
+  chai-as-promised@7.1.2(chai@4.4.1):
+    dependencies:
+      chai: 4.4.1
+      check-error: 1.0.3
+
   chai-bn@0.2.2(bn.js@5.2.1)(chai@4.4.1):
     dependencies:
       bn.js: 5.2.1
@@ -4341,6 +5099,8 @@ snapshots:
       title-case: 2.1.1
       upper-case: 1.1.3
       upper-case-first: 1.1.2
+
+  charenc@0.0.2: {}
 
   check-error@1.0.3:
     dependencies:
@@ -4406,6 +5166,13 @@ snapshots:
 
   clean-stack@2.2.0: {}
 
+  cli-table3@0.5.1:
+    dependencies:
+      object-assign: 4.1.1
+      string-width: 2.1.1
+    optionalDependencies:
+      colors: 1.4.0
+
   cliui@3.2.0:
     dependencies:
       string-width: 1.0.2
@@ -4444,9 +5211,30 @@ snapshots:
 
   command-exists@1.2.9: {}
 
+  command-line-args@5.2.1:
+    dependencies:
+      array-back: 3.1.0
+      find-replace: 3.0.0
+      lodash.camelcase: 4.3.0
+      typical: 4.0.0
+
+  command-line-usage@6.1.3:
+    dependencies:
+      array-back: 4.0.2
+      chalk: 2.4.2
+      table-layout: 1.0.2
+      typical: 5.2.0
+
   commander@3.0.2: {}
 
   concat-map@0.0.1: {}
+
+  concat-stream@1.6.2:
+    dependencies:
+      buffer-from: 1.1.2
+      inherits: 2.0.4
+      readable-stream: 2.3.8
+      typedarray: 0.0.6
 
   constant-case@2.0.0:
     dependencies:
@@ -4511,6 +5299,8 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
+  crypt@0.0.2: {}
+
   crypto-addr-codec@0.1.8:
     dependencies:
       base-x: 3.0.9
@@ -4540,13 +5330,19 @@ snapshots:
     dependencies:
       assert-plus: 1.0.0
 
+  death@1.1.0: {}
+
   debug@2.6.9:
     dependencies:
       ms: 2.0.0
 
-  debug@4.3.4(supports-color@8.1.1):
+  debug@4.3.4:
     dependencies:
       ms: 2.1.2
+
+  debug@4.3.7(supports-color@8.1.1):
+    dependencies:
+      ms: 2.1.3
     optionalDependencies:
       supports-color: 8.1.1
 
@@ -4567,6 +5363,10 @@ snapshots:
   deep-eql@4.1.4:
     dependencies:
       type-detect: 4.0.8
+
+  deep-extend@0.6.0: {}
+
+  deep-is@0.1.4: {}
 
   defer-to-connect@2.0.1: {}
 
@@ -4591,7 +5391,15 @@ snapshots:
 
   diff@4.0.2: {}
 
-  diff@5.0.0: {}
+  diff@5.2.0: {}
+
+  difflib@0.2.4:
+    dependencies:
+      heap: 0.2.7
+
+  dir-glob@3.0.1:
+    dependencies:
+      path-type: 4.0.0
 
   dom-serializer@2.0.0:
     dependencies:
@@ -4740,6 +5548,15 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
+  escodegen@1.8.1:
+    dependencies:
+      esprima: 2.7.3
+      estraverse: 1.9.3
+      esutils: 2.0.3
+      optionator: 0.8.3
+    optionalDependencies:
+      source-map: 0.2.0
+
   esniff@2.0.1:
     dependencies:
       d: 1.0.2
@@ -4747,12 +5564,40 @@ snapshots:
       event-emitter: 0.3.5
       type: 2.7.3
 
+  esprima@2.7.3: {}
+
+  esprima@4.0.1: {}
+
+  estraverse@1.9.3: {}
+
+  esutils@2.0.3: {}
+
   etag@1.8.1: {}
 
   eth-ens-namehash@2.0.8:
     dependencies:
       idna-uts46-hx: 2.3.1
       js-sha3: 0.5.7
+
+  eth-gas-reporter@0.2.27(bufferutil@4.0.8)(utf-8-validate@5.0.10):
+    dependencies:
+      '@solidity-parser/parser': 0.14.5
+      axios: 1.7.2
+      cli-table3: 0.5.1
+      colors: 1.4.0
+      ethereum-cryptography: 1.2.0
+      ethers: 5.7.2(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      fs-readdir-recursive: 1.1.0
+      lodash: 4.17.21
+      markdown-table: 1.1.3
+      mocha: 10.8.2
+      req-cwd: 2.0.0
+      sha1: 1.1.1
+      sync-request: 6.1.0
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - utf-8-validate
 
   eth-lib@0.1.29(bufferutil@4.0.8)(utf-8-validate@5.0.10):
     dependencies:
@@ -4985,30 +5830,46 @@ snapshots:
 
   fast-deep-equal@3.1.3: {}
 
+  fast-glob@3.3.2:
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      '@nodelib/fs.walk': 1.2.8
+      glob-parent: 5.1.2
+      merge2: 1.4.1
+      micromatch: 4.0.7
+
   fast-json-stable-stringify@2.1.0: {}
 
-  fhenix-hardhat-plugin@0.2.1(bufferutil@4.0.8)(hardhat@2.19.3(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@18.15.13)(typescript@5.5.4))(typescript@5.5.4)(utf-8-validate@5.0.10))(utf-8-validate@5.0.10):
+  fast-levenshtein@2.0.6: {}
+
+  fast-uri@3.0.3: {}
+
+  fastq@1.17.1:
+    dependencies:
+      reusify: 1.0.4
+
+  fhenix-hardhat-docker@0.3.0-alpha.2(hardhat@2.19.3(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@20.17.6)(typescript@5.5.4))(typescript@5.5.4)(utf-8-validate@5.0.10)):
+    dependencies:
+      chalk: 4.1.2
+      hardhat: 2.19.3(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@20.17.6)(typescript@5.5.4))(typescript@5.5.4)(utf-8-validate@5.0.10)
+
+  fhenix-hardhat-plugin@0.3.0-alpha.2(bufferutil@4.0.8)(hardhat@2.19.3(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@20.17.6)(typescript@5.5.4))(typescript@5.5.4)(utf-8-validate@5.0.10))(utf-8-validate@5.0.10):
     dependencies:
       axios: 1.7.2
       chalk: 4.1.2
       ethers: 6.13.1(bufferutil@4.0.8)(utf-8-validate@5.0.10)
-      fhenixjs: 0.2.1(bufferutil@4.0.8)(utf-8-validate@5.0.10)
-      hardhat: 2.19.3(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@18.15.13)(typescript@5.5.4))(typescript@5.5.4)(utf-8-validate@5.0.10)
+      fhenixjs: 0.4.0-alpha.6
+      hardhat: 2.19.3(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@20.17.6)(typescript@5.5.4))(typescript@5.5.4)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - bufferutil
       - debug
       - utf-8-validate
 
-  fhenixjs@0.2.1(bufferutil@4.0.8)(utf-8-validate@5.0.10):
+  fhenixjs@0.4.0-alpha.6:
     dependencies:
-      ethers: 6.13.1(bufferutil@4.0.8)(utf-8-validate@5.0.10)
-      node-tfhe: 0.6.4
-      tfhe: 0.6.4
+      '@types/node': 20.17.6
       tweetnacl: 1.0.3
       tweetnacl-util: 0.15.1
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
 
   fill-range@7.0.1:
     dependencies:
@@ -5029,6 +5890,10 @@ snapshots:
       unpipe: 1.0.0
     transitivePeerDependencies:
       - supports-color
+
+  find-replace@3.0.0:
+    dependencies:
+      array-back: 3.1.0
 
   find-up@1.1.2:
     dependencies:
@@ -5053,7 +5918,7 @@ snapshots:
 
   follow-redirects@1.15.2(debug@4.3.4):
     optionalDependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
 
   follow-redirects@1.15.6: {}
 
@@ -5109,9 +5974,18 @@ snapshots:
       jsonfile: 4.0.0
       universalify: 0.1.2
 
+  fs-extra@9.1.0:
+    dependencies:
+      at-least-node: 1.0.0
+      graceful-fs: 4.2.11
+      jsonfile: 6.1.0
+      universalify: 2.0.1
+
   fs-minipass@1.2.7:
     dependencies:
       minipass: 2.9.0
+
+  fs-readdir-recursive@1.1.0: {}
 
   fs.realpath@1.0.0: {}
 
@@ -5153,6 +6027,8 @@ snapshots:
       has-symbols: 1.0.3
       hasown: 2.0.0
 
+  get-port@3.2.0: {}
+
   get-stream@5.2.0:
     dependencies:
       pump: 3.0.0
@@ -5168,9 +6044,31 @@ snapshots:
     dependencies:
       assert-plus: 1.0.0
 
+  ghost-testrpc@0.0.2:
+    dependencies:
+      chalk: 2.4.2
+      node-emoji: 1.11.0
+
   glob-parent@5.1.2:
     dependencies:
       is-glob: 4.0.3
+
+  glob@5.0.15:
+    dependencies:
+      inflight: 1.0.6
+      inherits: 2.0.4
+      minimatch: 3.1.2
+      once: 1.4.0
+      path-is-absolute: 1.0.1
+
+  glob@7.1.7:
+    dependencies:
+      fs.realpath: 1.0.0
+      inflight: 1.0.6
+      inherits: 2.0.4
+      minimatch: 3.1.2
+      once: 1.4.0
+      path-is-absolute: 1.0.1
 
   glob@7.2.0:
     dependencies:
@@ -5190,6 +6088,24 @@ snapshots:
       once: 1.4.0
       path-is-absolute: 1.0.1
 
+  glob@8.1.0:
+    dependencies:
+      fs.realpath: 1.0.0
+      inflight: 1.0.6
+      inherits: 2.0.4
+      minimatch: 5.1.6
+      once: 1.4.0
+
+  global-modules@2.0.0:
+    dependencies:
+      global-prefix: 3.0.0
+
+  global-prefix@3.0.0:
+    dependencies:
+      ini: 1.3.8
+      kind-of: 6.0.3
+      which: 1.3.1
+
   global@4.4.0:
     dependencies:
       min-document: 2.19.0
@@ -5198,6 +6114,17 @@ snapshots:
   globalthis@1.0.3:
     dependencies:
       define-properties: 1.2.0
+
+  globby@10.0.2:
+    dependencies:
+      '@types/glob': 7.2.0
+      array-union: 2.1.0
+      dir-glob: 3.0.1
+      fast-glob: 3.3.2
+      glob: 7.2.3
+      ignore: 5.3.2
+      merge2: 1.4.1
+      slash: 3.0.0
 
   gopd@1.0.1:
     dependencies:
@@ -5251,13 +6178,25 @@ snapshots:
       ajv: 6.12.6
       har-schema: 2.0.0
 
-  hardhat-exposed@0.3.15(hardhat@2.19.3(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@18.15.13)(typescript@5.5.4))(typescript@5.5.4)(utf-8-validate@5.0.10)):
+  hardhat-exposed@0.3.15(hardhat@2.19.3(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@20.17.6)(typescript@5.5.4))(typescript@5.5.4)(utf-8-validate@5.0.10)):
     dependencies:
-      hardhat: 2.19.3(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@18.15.13)(typescript@5.5.4))(typescript@5.5.4)(utf-8-validate@5.0.10)
+      hardhat: 2.19.3(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@20.17.6)(typescript@5.5.4))(typescript@5.5.4)(utf-8-validate@5.0.10)
       micromatch: 4.0.7
       solidity-ast: 0.4.55
 
-  hardhat@2.19.3(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@18.15.13)(typescript@5.5.4))(typescript@5.5.4)(utf-8-validate@5.0.10):
+  hardhat-gas-reporter@1.0.10(bufferutil@4.0.8)(hardhat@2.19.3(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@20.17.6)(typescript@5.5.4))(typescript@5.5.4)(utf-8-validate@5.0.10))(utf-8-validate@5.0.10):
+    dependencies:
+      array-uniq: 1.0.3
+      eth-gas-reporter: 0.2.27(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      hardhat: 2.19.3(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@20.17.6)(typescript@5.5.4))(typescript@5.5.4)(utf-8-validate@5.0.10)
+      sha1: 1.1.1
+    transitivePeerDependencies:
+      - '@codechecks/client'
+      - bufferutil
+      - debug
+      - utf-8-validate
+
+  hardhat@2.19.3(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@20.17.6)(typescript@5.5.4))(typescript@5.5.4)(utf-8-validate@5.0.10):
     dependencies:
       '@ethersproject/abi': 5.7.0
       '@metamask/eth-sig-util': 4.0.1
@@ -5281,7 +6220,7 @@ snapshots:
       chalk: 2.4.2
       chokidar: 3.5.3
       ci-info: 2.0.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       enquirer: 2.3.6
       env-paths: 2.2.1
       ethereum-cryptography: 1.2.0
@@ -5295,7 +6234,7 @@ snapshots:
       keccak: 3.0.3
       lodash: 4.17.21
       mnemonist: 0.38.5
-      mocha: 10.1.0
+      mocha: 10.8.2
       p-map: 4.0.0
       raw-body: 2.5.2
       resolve: 1.17.0
@@ -5308,7 +6247,7 @@ snapshots:
       uuid: 8.3.2
       ws: 7.5.9(bufferutil@4.0.8)(utf-8-validate@5.0.10)
     optionalDependencies:
-      ts-node: 10.9.2(@types/node@18.15.13)(typescript@5.5.4)
+      ts-node: 10.9.2(@types/node@20.17.6)(typescript@5.5.4)
       typescript: 5.5.4
     transitivePeerDependencies:
       - bufferutil
@@ -5316,6 +6255,8 @@ snapshots:
       - utf-8-validate
 
   has-bigints@1.0.2: {}
+
+  has-flag@1.0.0: {}
 
   has-flag@3.0.0: {}
 
@@ -5364,6 +6305,8 @@ snapshots:
       no-case: 2.3.2
       upper-case: 1.1.3
 
+  heap@0.2.7: {}
+
   highlight.js@10.7.3: {}
 
   highlightjs-solidity@2.0.6: {}
@@ -5383,6 +6326,13 @@ snapshots:
       domutils: 3.1.0
       entities: 4.5.0
 
+  http-basic@8.1.3:
+    dependencies:
+      caseless: 0.12.0
+      concat-stream: 1.6.2
+      http-response-object: 3.0.2
+      parse-cache-control: 1.0.1
+
   http-cache-semantics@4.1.1: {}
 
   http-errors@2.0.0:
@@ -5394,6 +6344,10 @@ snapshots:
       toidentifier: 1.0.1
 
   http-https@1.0.0: {}
+
+  http-response-object@3.0.2:
+    dependencies:
+      '@types/node': 10.17.60
 
   http-signature@1.2.0:
     dependencies:
@@ -5414,7 +6368,7 @@ snapshots:
   https-proxy-agent@5.0.1:
     dependencies:
       agent-base: 6.0.2
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.7(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -5428,6 +6382,8 @@ snapshots:
 
   ieee754@1.2.1: {}
 
+  ignore@5.3.2: {}
+
   immutable@4.3.0: {}
 
   indent-string@4.0.0: {}
@@ -5439,11 +6395,15 @@ snapshots:
 
   inherits@2.0.4: {}
 
+  ini@1.3.8: {}
+
   internal-slot@1.0.5:
     dependencies:
       get-intrinsic: 1.2.2
       has: 1.0.3
       side-channel: 1.0.4
+
+  interpret@1.4.0: {}
 
   invert-kv@1.0.0: {}
 
@@ -5492,6 +6452,8 @@ snapshots:
   is-fullwidth-code-point@1.0.0:
     dependencies:
       number-is-nan: 1.0.1
+
+  is-fullwidth-code-point@2.0.0: {}
 
   is-fullwidth-code-point@3.0.0: {}
 
@@ -5556,7 +6518,11 @@ snapshots:
     dependencies:
       call-bind: 1.0.5
 
+  isarray@1.0.0: {}
+
   isarray@2.0.5: {}
+
+  isexe@2.0.0: {}
 
   isstream@0.1.2: {}
 
@@ -5568,6 +6534,11 @@ snapshots:
 
   js-sha3@0.8.0: {}
 
+  js-yaml@3.14.1:
+    dependencies:
+      argparse: 1.0.10
+      esprima: 4.0.1
+
   js-yaml@4.1.0:
     dependencies:
       argparse: 2.0.1
@@ -5577,6 +6548,8 @@ snapshots:
   json-buffer@3.0.1: {}
 
   json-schema-traverse@0.4.1: {}
+
+  json-schema-traverse@1.0.0: {}
 
   json-schema@0.4.0: {}
 
@@ -5589,6 +6562,14 @@ snapshots:
   jsonfile@4.0.0:
     optionalDependencies:
       graceful-fs: 4.2.11
+
+  jsonfile@6.1.0:
+    dependencies:
+      universalify: 2.0.1
+    optionalDependencies:
+      graceful-fs: 4.2.11
+
+  jsonschema@1.4.1: {}
 
   jsprim@1.4.2:
     dependencies:
@@ -5606,6 +6587,8 @@ snapshots:
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
+
+  kind-of@6.0.3: {}
 
   klaw@1.3.1:
     optionalDependencies:
@@ -5626,6 +6609,11 @@ snapshots:
     dependencies:
       browser-level: 1.0.1
       classic-level: 1.3.0
+
+  levn@0.3.0:
+    dependencies:
+      prelude-ls: 1.1.2
+      type-check: 0.3.2
 
   load-json-file@1.1.0:
     dependencies:
@@ -5650,11 +6638,17 @@ snapshots:
 
   lodash.assign@4.2.0: {}
 
+  lodash.camelcase@4.3.0: {}
+
+  lodash.clonedeep@4.5.0: {}
+
   lodash.flatten@4.4.0: {}
 
   lodash.isequal@4.5.0: {}
 
   lodash.merge@4.6.2: {}
+
+  lodash.truncate@4.4.2: {}
 
   lodash@4.17.21: {}
 
@@ -5685,6 +6679,8 @@ snapshots:
 
   make-error@1.3.6: {}
 
+  markdown-table@1.1.3: {}
+
   mcl-wasm@0.7.9: {}
 
   md5.js@1.3.5:
@@ -5704,6 +6700,8 @@ snapshots:
   memorystream@0.3.1: {}
 
   merge-descriptors@1.0.1: {}
+
+  merge2@1.4.1: {}
 
   methods@1.1.2: {}
 
@@ -5738,7 +6736,7 @@ snapshots:
     dependencies:
       brace-expansion: 1.1.11
 
-  minimatch@5.0.1:
+  minimatch@5.1.6:
     dependencies:
       brace-expansion: 2.0.1
 
@@ -5761,34 +6759,35 @@ snapshots:
     dependencies:
       minimist: 1.2.8
 
+  mkdirp@1.0.4: {}
+
   mkdirp@3.0.1: {}
 
   mnemonist@0.38.5:
     dependencies:
       obliterator: 2.0.4
 
-  mocha@10.1.0:
+  mocha@10.8.2:
     dependencies:
-      ansi-colors: 4.1.1
+      ansi-colors: 4.1.3
       browser-stdout: 1.3.1
       chokidar: 3.5.3
-      debug: 4.3.4(supports-color@8.1.1)
-      diff: 5.0.0
+      debug: 4.3.7(supports-color@8.1.1)
+      diff: 5.2.0
       escape-string-regexp: 4.0.0
       find-up: 5.0.0
-      glob: 7.2.0
+      glob: 8.1.0
       he: 1.2.0
       js-yaml: 4.1.0
       log-symbols: 4.1.0
-      minimatch: 5.0.1
+      minimatch: 5.1.6
       ms: 2.1.3
-      nanoid: 3.3.3
-      serialize-javascript: 6.0.0
+      serialize-javascript: 6.0.2
       strip-json-comments: 3.1.1
       supports-color: 8.1.1
-      workerpool: 6.2.1
+      workerpool: 6.5.1
       yargs: 16.2.0
-      yargs-parser: 20.2.4
+      yargs-parser: 20.2.9
       yargs-unparser: 2.0.0
 
   mock-fs@4.14.0: {}
@@ -5830,8 +6829,6 @@ snapshots:
 
   nano-json-stream-parser@0.1.2: {}
 
-  nanoid@3.3.3: {}
-
   napi-macros@2.2.2: {}
 
   negotiator@0.6.3: {}
@@ -5846,15 +6843,23 @@ snapshots:
 
   node-addon-api@2.0.2: {}
 
+  node-emoji@1.11.0:
+    dependencies:
+      lodash: 4.17.21
+
   node-fetch@2.7.0:
     dependencies:
       whatwg-url: 5.0.0
 
   node-gyp-build@4.6.0: {}
 
-  node-tfhe@0.6.4: {}
-
   nofilter@1.0.4: {}
+
+  nofilter@3.1.0: {}
+
+  nopt@3.0.6:
+    dependencies:
+      abbrev: 1.0.9
 
   normalize-package-data@2.5.0:
     dependencies:
@@ -5907,6 +6912,17 @@ snapshots:
     dependencies:
       wrappy: 1.0.2
 
+  optionator@0.8.3:
+    dependencies:
+      deep-is: 0.1.4
+      fast-levenshtein: 2.0.6
+      levn: 0.3.0
+      prelude-ls: 1.1.2
+      type-check: 0.3.2
+      word-wrap: 1.2.5
+
+  ordinal@1.0.3: {}
+
   os-locale@1.4.0:
     dependencies:
       lcid: 1.0.0
@@ -5955,6 +6971,8 @@ snapshots:
     dependencies:
       no-case: 2.3.2
 
+  parse-cache-control@1.0.1: {}
+
   parse-headers@2.0.5: {}
 
   parse-json@2.2.0:
@@ -6001,6 +7019,8 @@ snapshots:
       pify: 2.3.0
       pinkie-promise: 2.0.1
 
+  path-type@4.0.0: {}
+
   pathval@1.1.1: {}
 
   pbkdf2@3.1.2:
@@ -6017,13 +7037,25 @@ snapshots:
 
   pify@2.3.0: {}
 
+  pify@4.0.1: {}
+
   pinkie-promise@2.0.1:
     dependencies:
       pinkie: 2.0.4
 
   pinkie@2.0.4: {}
 
+  prelude-ls@1.1.2: {}
+
+  prettier@2.8.8: {}
+
+  process-nextick-args@2.0.1: {}
+
   process@0.11.10: {}
+
+  promise@8.3.0:
+    dependencies:
+      asap: 2.0.6
 
   proxy-addr@2.0.7:
     dependencies:
@@ -6085,6 +7117,16 @@ snapshots:
       normalize-package-data: 2.5.0
       path-type: 1.1.0
 
+  readable-stream@2.3.8:
+    dependencies:
+      core-util-is: 1.0.2
+      inherits: 2.0.4
+      isarray: 1.0.0
+      process-nextick-args: 2.0.1
+      safe-buffer: 5.1.2
+      string_decoder: 1.1.1
+      util-deprecate: 1.0.2
+
   readable-stream@3.6.2:
     dependencies:
       inherits: 2.0.4
@@ -6095,6 +7137,16 @@ snapshots:
     dependencies:
       picomatch: 2.3.1
 
+  rechoir@0.6.2:
+    dependencies:
+      resolve: 1.17.0
+
+  recursive-readdir@2.2.3:
+    dependencies:
+      minimatch: 3.1.2
+
+  reduce-flatten@2.0.0: {}
+
   regenerator-runtime@0.14.1: {}
 
   regexp.prototype.flags@1.5.1:
@@ -6102,6 +7154,14 @@ snapshots:
       call-bind: 1.0.5
       define-properties: 1.2.0
       set-function-name: 2.0.1
+
+  req-cwd@2.0.0:
+    dependencies:
+      req-from: 2.0.0
+
+  req-from@2.0.0:
+    dependencies:
+      resolve-from: 3.0.0
 
   request@2.88.2:
     dependencies:
@@ -6136,6 +7196,10 @@ snapshots:
 
   resolve-alpn@1.2.1: {}
 
+  resolve-from@3.0.0: {}
+
+  resolve@1.1.7: {}
+
   resolve@1.17.0:
     dependencies:
       path-parse: 1.0.7
@@ -6143,6 +7207,8 @@ snapshots:
   responselike@2.0.1:
     dependencies:
       lowercase-keys: 2.0.0
+
+  reusify@1.0.4: {}
 
   rimraf@2.7.1:
     dependencies:
@@ -6160,6 +7226,10 @@ snapshots:
       bn.js: 5.2.1
 
   run-parallel-limit@1.1.0:
+    dependencies:
+      queue-microtask: 1.2.3
+
+  run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
 
@@ -6183,6 +7253,23 @@ snapshots:
       is-regex: 1.1.4
 
   safer-buffer@2.1.2: {}
+
+  sc-istanbul@0.4.6:
+    dependencies:
+      abbrev: 1.0.9
+      async: 1.5.2
+      escodegen: 1.8.1
+      esprima: 2.7.3
+      glob: 5.0.15
+      handlebars: 4.7.7
+      js-yaml: 3.14.1
+      mkdirp: 0.5.6
+      nopt: 3.0.6
+      once: 1.4.0
+      resolve: 1.1.7
+      supports-color: 3.2.3
+      which: 1.3.1
+      wordwrap: 1.0.0
 
   scrypt-js@2.0.4: {}
 
@@ -6223,7 +7310,7 @@ snapshots:
       no-case: 2.3.2
       upper-case-first: 1.1.2
 
-  serialize-javascript@6.0.0:
+  serialize-javascript@6.0.2:
     dependencies:
       randombytes: 2.1.0
 
@@ -6272,9 +7359,20 @@ snapshots:
       inherits: 2.0.4
       safe-buffer: 5.2.1
 
+  sha1@1.1.1:
+    dependencies:
+      charenc: 0.0.2
+      crypt: 0.0.2
+
   sha3@2.1.4:
     dependencies:
       buffer: 6.0.3
+
+  shelljs@0.8.5:
+    dependencies:
+      glob: 7.2.3
+      interpret: 1.4.0
+      rechoir: 0.6.2
 
   side-channel@1.0.4:
     dependencies:
@@ -6289,6 +7387,14 @@ snapshots:
       decompress-response: 3.3.0
       once: 1.4.0
       simple-concat: 1.0.1
+
+  slash@3.0.0: {}
+
+  slice-ansi@4.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      astral-regex: 2.0.0
+      is-fullwidth-code-point: 3.0.0
 
   snake-case@2.1.0:
     dependencies:
@@ -6320,16 +7426,44 @@ snapshots:
     dependencies:
       array.prototype.findlast: 1.2.3
 
-  solidity-docgen@0.6.0-beta.36(hardhat@2.19.3(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@18.15.13)(typescript@5.5.4))(typescript@5.5.4)(utf-8-validate@5.0.10)):
+  solidity-coverage@0.8.13(hardhat@2.19.3(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@20.17.6)(typescript@5.5.4))(typescript@5.5.4)(utf-8-validate@5.0.10)):
+    dependencies:
+      '@ethersproject/abi': 5.7.0
+      '@solidity-parser/parser': 0.18.0
+      chalk: 2.4.2
+      death: 1.1.0
+      difflib: 0.2.4
+      fs-extra: 8.1.0
+      ghost-testrpc: 0.0.2
+      global-modules: 2.0.0
+      globby: 10.0.2
+      hardhat: 2.19.3(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@20.17.6)(typescript@5.5.4))(typescript@5.5.4)(utf-8-validate@5.0.10)
+      jsonschema: 1.4.1
+      lodash: 4.17.21
+      mocha: 10.8.2
+      node-emoji: 1.11.0
+      pify: 4.0.1
+      recursive-readdir: 2.2.3
+      sc-istanbul: 0.4.6
+      semver: 7.6.3
+      shelljs: 0.8.5
+      web3-utils: 1.10.4
+
+  solidity-docgen@0.6.0-beta.36(hardhat@2.19.3(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@20.17.6)(typescript@5.5.4))(typescript@5.5.4)(utf-8-validate@5.0.10)):
     dependencies:
       handlebars: 4.7.7
-      hardhat: 2.19.3(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@18.15.13)(typescript@5.5.4))(typescript@5.5.4)(utf-8-validate@5.0.10)
+      hardhat: 2.19.3(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@20.17.6)(typescript@5.5.4))(typescript@5.5.4)(utf-8-validate@5.0.10)
       solidity-ast: 0.4.55
 
   source-map-support@0.5.21:
     dependencies:
       buffer-from: 1.1.2
       source-map: 0.6.1
+
+  source-map@0.2.0:
+    dependencies:
+      amdefine: 1.0.1
+    optional: true
 
   source-map@0.6.1: {}
 
@@ -6346,6 +7480,8 @@ snapshots:
       spdx-license-ids: 3.0.18
 
   spdx-license-ids@3.0.18: {}
+
+  sprintf-js@1.0.3: {}
 
   sshpk@1.18.0:
     dependencies:
@@ -6369,11 +7505,18 @@ snapshots:
 
   strict-uri-encode@1.1.0: {}
 
+  string-format@2.0.0: {}
+
   string-width@1.0.2:
     dependencies:
       code-point-at: 1.1.0
       is-fullwidth-code-point: 1.0.0
       strip-ansi: 3.0.1
+
+  string-width@2.1.1:
+    dependencies:
+      is-fullwidth-code-point: 2.0.0
+      strip-ansi: 4.0.0
 
   string-width@4.2.3:
     dependencies:
@@ -6398,6 +7541,10 @@ snapshots:
       call-bind: 1.0.5
       define-properties: 1.2.0
       es-abstract: 1.22.3
+
+  string_decoder@1.1.1:
+    dependencies:
+      safe-buffer: 5.1.2
 
   string_decoder@1.3.0:
     dependencies:
@@ -6426,6 +7573,10 @@ snapshots:
   strip-indent@2.0.0: {}
 
   strip-json-comments@3.1.1: {}
+
+  supports-color@3.2.3:
+    dependencies:
+      has-flag: 1.0.0
 
   supports-color@5.5.0:
     dependencies:
@@ -6462,6 +7613,31 @@ snapshots:
       - supports-color
       - utf-8-validate
 
+  sync-request@6.1.0:
+    dependencies:
+      http-response-object: 3.0.2
+      sync-rpc: 1.3.6
+      then-request: 6.0.2
+
+  sync-rpc@1.3.6:
+    dependencies:
+      get-port: 3.2.0
+
+  table-layout@1.0.2:
+    dependencies:
+      array-back: 4.0.2
+      deep-extend: 0.6.0
+      typical: 5.2.0
+      wordwrapjs: 4.0.1
+
+  table@6.8.2:
+    dependencies:
+      ajv: 8.17.1
+      lodash.truncate: 4.4.2
+      slice-ansi: 4.0.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
   tar@4.4.19:
     dependencies:
       chownr: 1.1.4
@@ -6474,7 +7650,19 @@ snapshots:
 
   testrpc@0.0.1: {}
 
-  tfhe@0.6.4: {}
+  then-request@6.0.2:
+    dependencies:
+      '@types/concat-stream': 1.6.1
+      '@types/form-data': 0.0.33
+      '@types/node': 8.10.66
+      '@types/qs': 6.9.17
+      caseless: 0.12.0
+      concat-stream: 1.6.2
+      form-data: 2.3.3
+      http-basic: 8.1.3
+      http-response-object: 3.0.2
+      promise: 8.3.0
+      qs: 6.11.0
 
   timed-out@4.0.1: {}
 
@@ -6500,14 +7688,25 @@ snapshots:
 
   tr46@0.0.3: {}
 
-  ts-node@10.9.2(@types/node@18.15.13)(typescript@5.5.4):
+  ts-command-line-args@2.5.1:
+    dependencies:
+      chalk: 4.1.2
+      command-line-args: 5.2.1
+      command-line-usage: 6.1.3
+      string-format: 2.0.0
+
+  ts-essentials@7.0.3(typescript@5.5.4):
+    dependencies:
+      typescript: 5.5.4
+
+  ts-node@10.9.2(@types/node@20.17.6)(typescript@5.5.4):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
-      '@types/node': 18.15.13
+      '@types/node': 20.17.6
       acorn: 8.12.1
       acorn-walk: 8.3.3
       arg: 4.1.3
@@ -6534,6 +7733,10 @@ snapshots:
 
   tweetnacl@1.0.3: {}
 
+  type-check@0.3.2:
+    dependencies:
+      prelude-ls: 1.1.2
+
   type-detect@4.0.8: {}
 
   type-fest@0.21.3: {}
@@ -6546,6 +7749,22 @@ snapshots:
       mime-types: 2.1.35
 
   type@2.7.3: {}
+
+  typechain@8.3.2(typescript@5.5.4):
+    dependencies:
+      '@types/prettier': 2.7.3
+      debug: 4.3.7(supports-color@8.1.1)
+      fs-extra: 7.0.1
+      glob: 7.1.7
+      js-sha3: 0.8.0
+      lodash: 4.17.21
+      mkdirp: 1.0.4
+      prettier: 2.8.8
+      ts-command-line-args: 2.5.1
+      ts-essentials: 7.0.3(typescript@5.5.4)
+      typescript: 5.5.4
+    transitivePeerDependencies:
+      - supports-color
 
   typed-array-buffer@1.0.0:
     dependencies:
@@ -6578,7 +7797,13 @@ snapshots:
     dependencies:
       is-typedarray: 1.0.0
 
+  typedarray@0.0.6: {}
+
   typescript@5.5.4: {}
+
+  typical@4.0.0: {}
+
+  typical@5.2.0: {}
 
   uglify-js@3.17.4:
     optional: true
@@ -6594,11 +7819,15 @@ snapshots:
 
   underscore@1.13.6: {}
 
+  undici-types@6.19.8: {}
+
   undici@5.22.1:
     dependencies:
       busboy: 1.6.0
 
   universalify@0.1.2: {}
+
+  universalify@2.0.1: {}
 
   unpipe@1.0.0: {}
 
@@ -7106,11 +8335,22 @@ snapshots:
       gopd: 1.0.1
       has-tostringtag: 1.0.0
 
+  which@1.3.1:
+    dependencies:
+      isexe: 2.0.0
+
   window-size@0.2.0: {}
+
+  word-wrap@1.2.5: {}
 
   wordwrap@1.0.0: {}
 
-  workerpool@6.2.1: {}
+  wordwrapjs@4.0.1:
+    dependencies:
+      reduce-flatten: 2.0.0
+      typical: 5.2.0
+
+  workerpool@6.5.1: {}
 
   wrap-ansi@2.1.0:
     dependencies:
@@ -7187,7 +8427,7 @@ snapshots:
       camelcase: 3.0.0
       lodash.assign: 4.2.0
 
-  yargs-parser@20.2.4: {}
+  yargs-parser@20.2.9: {}
 
   yargs-unparser@2.0.0:
     dependencies:
@@ -7204,7 +8444,7 @@ snapshots:
       require-directory: 2.1.1
       string-width: 4.2.3
       y18n: 5.0.8
-      yargs-parser: 20.2.4
+      yargs-parser: 20.2.9
 
   yargs@4.8.1:
     dependencies:

--- a/test/permitV2/PermissionedV2.test.ts
+++ b/test/permitV2/PermissionedV2.test.ts
@@ -1,0 +1,513 @@
+import { expect } from 'chai'
+import { ethers, fhenixjs } from 'hardhat'
+import { time } from '@nomicfoundation/hardhat-network-helpers'
+
+import { createExpiration, getLastBlockTimestamp, getTokensFromFaucet } from './chain-utils'
+import { hours } from '@nomicfoundation/hardhat-network-helpers/dist/src/helpers/time/duration'
+import { generatePermitV2, extractPermissionV2, reSignSharedPermit } from './permit-v2-utils'
+import { PermissionedV2Counter__factory, PermissionedV2RevokableValidator__factory, PermissionedV2TimestampValidator__factory } from '../../types'
+import { GenerateSealingKey } from 'fhenixjs'
+
+describe('PermissionedV2', function () {
+	async function permissionedV2Fixture() {
+		const signer = (await ethers.getSigners())[0]
+		const bob = (await ethers.getSigners())[1]
+		const ada = (await ethers.getSigners())[2]
+
+		await getTokensFromFaucet(signer.address)
+		await getTokensFromFaucet(bob.address)
+		await getTokensFromFaucet(ada.address)
+
+		// Deploy Counter1
+		const counterFactory = (await ethers.getContractFactory('PermissionedV2Counter')) as PermissionedV2Counter__factory
+		const counter1 = await counterFactory.deploy()
+		await counter1.waitForDeployment()
+		const counter1Address = await counter1.getAddress()
+
+		// Deploy Counter2
+		const counter2 = await counterFactory.deploy()
+		await counter2.waitForDeployment()
+		const counter2Address = await counter2.getAddress()
+
+		// Deploy example revokable validator (id)
+		const permissionRevokableValidatorFactory = (await ethers.getContractFactory(
+			'PermissionedV2RevokableValidator'
+		)) as PermissionedV2RevokableValidator__factory
+		const permissionRevokableValidator = await permissionRevokableValidatorFactory.deploy()
+		await permissionRevokableValidator.waitForDeployment()
+		const permissionRevokableValidatorAddress = await permissionRevokableValidator.getAddress()
+
+		// Deploy example revokable validator (timestamp)
+		const permissionTimestampValidatorFactory = (await ethers.getContractFactory(
+			'PermissionedV2TimestampValidator'
+		)) as PermissionedV2TimestampValidator__factory
+		const permissionTimestampValidator = await permissionTimestampValidatorFactory.deploy()
+		await permissionTimestampValidator.waitForDeployment()
+		const permissionTimestampValidatorAddress = await permissionTimestampValidator.getAddress()
+
+		return {
+			signer,
+			bob,
+			ada,
+			counter1,
+			counter1Address,
+			counter2,
+			counter2Address,
+			permissionRevokableValidator,
+			permissionRevokableValidatorAddress,
+			permissionTimestampValidator,
+			permissionTimestampValidatorAddress,
+		}
+	}
+
+	// =================================
+	//           GOLDEN PATHS
+	// =================================
+	describe('Golden paths', async () => {
+		it('Multi contract access (`permission.contracts`)', async () => {
+			const { bob, counter1, counter1Address, counter2, counter2Address } = await permissionedV2Fixture()
+
+			await counter1.connect(bob).add(await fhenixjs.encrypt_uint32(5))
+			await counter2.connect(bob).add(await fhenixjs.encrypt_uint32(3))
+
+			expect(await counter1.getCounter(bob.address)).to.eq(5, "Bob's counter1 value should be added")
+			expect(await counter2.getCounter(bob.address)).to.eq(3, "Bob's counter2 value should be added")
+
+			// Single permission for multiple contracts
+			const permit = await generatePermitV2(
+				{
+					issuer: bob.address,
+					contracts: [counter1Address, counter2Address],
+				},
+				ethers.provider,
+				bob
+			)
+			const permission = extractPermissionV2(permit)
+
+			const c1sealed = await counter1.connect(bob).getCounterPermitSealed(permission)
+			const c1unsealed = permit.sealingPair.unseal(c1sealed)
+			expect(c1unsealed).to.eq(5, 'Bobs counter1 unsealed value should match')
+
+			const c2sealed = await counter2.connect(bob).getCounterPermitSealed(permission)
+			const c2unsealed = permit.sealingPair.unseal(c2sealed)
+			expect(c2unsealed).to.eq(3, 'Bobs counter2 unsealed value should match')
+		})
+
+		it('Multi contract access (`permission.projects`)', async () => {
+			const { bob, counter1, counter2 } = await permissionedV2Fixture()
+
+			await counter1.connect(bob).add(await fhenixjs.encrypt_uint32(5))
+			await counter2.connect(bob).add(await fhenixjs.encrypt_uint32(3))
+
+			expect(await counter1.getCounter(bob.address)).to.eq(5, "Bob's counter1 value should be added")
+			expect(await counter2.getCounter(bob.address)).to.eq(3, "Bob's counter2 value should be added")
+
+			// Single permission for multiple contracts
+			const permit = await generatePermitV2(
+				{
+					issuer: bob.address,
+					projects: ['COUNTER'],
+				},
+				ethers.provider,
+				bob
+			)
+			const permission = extractPermissionV2(permit)
+
+			const c1sealed = await counter1.connect(bob).getCounterPermitSealed(permission)
+			const c1unsealed = permit.sealingPair.unseal(c1sealed)
+			expect(c1unsealed).to.eq(5, 'Bobs counter1 unsealed value should match')
+
+			const c2sealed = await counter2.connect(bob).getCounterPermitSealed(permission)
+			const c2unsealed = permit.sealingPair.unseal(c2sealed)
+			expect(c2unsealed).to.eq(3, 'Bobs counter2 unsealed value should match')
+		})
+
+		it('Access can revert', async () => {
+			const { bob, counter1 } = await permissionedV2Fixture()
+
+			await counter1.connect(bob).add(await fhenixjs.encrypt_uint32(5))
+
+			const permit = await generatePermitV2(
+				{
+					issuer: bob.address,
+				},
+				ethers.provider,
+				bob
+			)
+			const permission = extractPermissionV2(permit)
+
+			await expect(counter1.connect(bob).getCounterPermitSealed(permission)).to.be.revertedWithCustomError(counter1, 'PermissionInvalid_ContractUnauthorized')
+		})
+
+		it('Expiration', async () => {
+			const { bob, counter1 } = await permissionedV2Fixture()
+
+			await counter1.connect(bob).add(await fhenixjs.encrypt_uint32(5))
+
+			// Expiration date in future
+			const futureExpiration = await createExpiration(hours(24))
+			const permitWithFutureExpiration = await generatePermitV2(
+				{
+					issuer: bob.address,
+					projects: ['COUNTER'],
+					expiration: futureExpiration,
+				},
+				ethers.provider,
+				bob
+			)
+			const permissionWithFutureExpiration = extractPermissionV2(permitWithFutureExpiration)
+			await counter1.connect(bob).getCounterPermitSealed(permissionWithFutureExpiration)
+
+			// Expiration date in past
+			const pastExpiration = await createExpiration(-1)
+			const permitWithPastExpiration = await generatePermitV2(
+				{
+					issuer: bob.address,
+					projects: ['COUNTER'],
+					expiration: pastExpiration,
+				},
+				ethers.provider,
+				bob
+			)
+			const permissionWithPastExpiration = extractPermissionV2(permitWithPastExpiration)
+
+			await expect(counter1.connect(bob).getCounterPermitSealed(permissionWithPastExpiration)).to.be.revertedWithCustomError(
+				counter1,
+				'PermissionInvalid_Expired'
+			)
+		})
+
+		it('Sharing', async () => {
+			const { bob, ada, counter1 } = await permissionedV2Fixture()
+
+			await counter1.connect(bob).add(await fhenixjs.encrypt_uint32(5))
+
+			// Self
+			const bobPermitForSelf = await generatePermitV2(
+				{
+					issuer: bob.address,
+					projects: ['COUNTER'],
+				},
+				ethers.provider,
+				bob
+			)
+			const bobPermissionForSelf = extractPermissionV2(bobPermitForSelf)
+			const bobCallSealed = await counter1.connect(bob).getCounterPermitSealed(bobPermissionForSelf)
+
+			// Sharing
+			const bobPermitForSharing = await generatePermitV2(
+				{
+					issuer: bob.address,
+					projects: ['COUNTER'],
+					recipient: ada.address,
+				},
+				ethers.provider,
+				bob
+			)
+			const adaPermit = await reSignSharedPermit(bobPermitForSharing, ethers.provider, ada)
+			const adaPermission = extractPermissionV2(adaPermit)
+
+			// Expect not to revert
+			const adaCallSealed = await counter1.connect(ada).getCounterPermitSealed(adaPermission)
+
+			// Shared and Self results match
+			const bobCallUnsealed = bobPermitForSelf.sealingPair.unseal(bobCallSealed)
+			const adaCallUnsealed = adaPermit.sealingPair.unseal(adaCallSealed)
+			expect(bobCallUnsealed).to.eq(adaCallUnsealed, "Bob and Ada can both use bob's permission")
+		})
+	})
+
+	// =================================
+	//          SIG REVERSIONS
+	// =================================
+	describe('Signature reversions', async () => {
+		it('`permission.issuerSignature` (not shared)', async () => {
+			const { bob, ada, counter1, counter1Address, counter2, counter2Address } = await permissionedV2Fixture()
+
+			// Valid permission
+			const permit = await generatePermitV2(
+				{
+					issuer: bob.address,
+					contracts: [counter1Address],
+				},
+				ethers.provider,
+				bob
+			)
+			const permission = extractPermissionV2(permit)
+
+			// Valid (sanity check)
+			await counter1.getCounterPermitSealed(permission)
+
+			// Invalid (access Ada's data)
+			await expect(
+				counter1.getCounterPermitSealed({
+					...permission,
+					issuer: ada.address,
+				})
+			).to.be.revertedWithCustomError(counter1, 'PermissionInvalid_IssuerSignature')
+
+			// Invalid (access counter2 data)
+			await expect(
+				counter2.getCounterPermitSealed({
+					...permission,
+					contracts: [counter2Address],
+				})
+			).to.be.revertedWithCustomError(counter2, 'PermissionInvalid_IssuerSignature')
+		})
+
+		it('`permission.issuerSignature` (shared)', async () => {
+			const { signer, bob, ada, counter1, counter1Address } = await permissionedV2Fixture()
+
+			await counter1.connect(bob).add(await fhenixjs.encrypt_uint32(5))
+
+			// Valid permission
+			const bobPermit = await generatePermitV2(
+				{
+					issuer: bob.address,
+					contracts: [counter1Address],
+					recipient: signer.address,
+				},
+				ethers.provider,
+				bob
+			)
+			const signerPermit = await reSignSharedPermit(bobPermit, ethers.provider, signer)
+			const signerPermission = extractPermissionV2(signerPermit)
+
+			// Valid (sanity check)
+			const bobSealed = await counter1.getCounterPermitSealed(signerPermission)
+			expect(signerPermit.sealingPair.unseal(bobSealed)).to.eq(5, "Returns Bob's data")
+
+			// Invalid (Ada attempting to use Bob's permission shared with Signer)
+			//     Throws `PermissionInvalid_IssuerSignature` because the Permission data changed
+			//     by Ada is included in the fields signed by the original issuer.
+			bobPermit.recipient = ada.address
+			const adaPermit = await reSignSharedPermit({ ...bobPermit, recipient: ada.address }, ethers.provider, ada)
+			const adaPermission = extractPermissionV2(adaPermit)
+			await expect(counter1.getCounterPermitSealed(adaPermission)).to.be.revertedWithCustomError(counter1, 'PermissionInvalid_IssuerSignature')
+		})
+
+		it('`recipientSignature`', async () => {
+			const { signer, bob, counter1, counter1Address } = await permissionedV2Fixture()
+
+			await counter1.connect(bob).add(await fhenixjs.encrypt_uint32(5))
+
+			// Valid permission
+			const bobPermit = await generatePermitV2(
+				{
+					issuer: bob.address,
+					contracts: [counter1Address],
+					recipient: signer.address,
+				},
+				ethers.provider,
+				bob
+			)
+			const signerPermit = await reSignSharedPermit(bobPermit, ethers.provider, signer)
+			const signerPermission = extractPermissionV2(signerPermit)
+
+			// Valid (sanity check)
+			const bobSealed = await counter1.getCounterPermitSealed(signerPermission)
+			expect(signerPermit.sealingPair.unseal(bobSealed)).to.eq(5, "Returns Bob's data")
+
+			// Invalid (Ada attempting to use Signer's permission with her own sealingKey)
+			//     Throws `PermissionInvalid_RecipientSignature` because `sealingKey` is secured
+			//     as part of `recipientSignature`
+			const adaKeypair = await GenerateSealingKey()
+			await expect(
+				counter1.getCounterPermitSealed({
+					...signerPermission,
+					sealingKey: `0x${adaKeypair.publicKey}`,
+				})
+			).to.be.revertedWithCustomError(counter1, 'PermissionInvalid_RecipientSignature')
+		})
+	})
+
+	// =================================
+	//       EXTERNAL VALIDATORS
+	// =================================
+
+	describe('External validators', async () => {
+		it('revokable via id', async () => {
+			const { bob, ada, counter1, permissionRevokableValidator, permissionRevokableValidatorAddress } = await permissionedV2Fixture()
+
+			await counter1.connect(bob).add(await fhenixjs.encrypt_uint32(5))
+
+			// BOB: Create revokableId
+			await permissionRevokableValidator.connect(bob).createRevokableId()
+			const revokableId = 1
+
+			// BOB: Create self and sharable permits with validator
+			const bobPermitSelf = await generatePermitV2(
+				{
+					issuer: bob.address,
+					projects: ['COUNTER'],
+					validatorId: revokableId,
+					validatorContract: permissionRevokableValidatorAddress,
+				},
+				ethers.provider,
+				bob
+			)
+			const bobPermission = extractPermissionV2(bobPermitSelf)
+			const bobPermitShared = await generatePermitV2(
+				{
+					issuer: bob.address,
+					projects: ['COUNTER'],
+					validatorId: revokableId,
+					validatorContract: permissionRevokableValidatorAddress,
+					recipient: ada.address,
+				},
+				ethers.provider,
+				bob
+			)
+
+			// ADA: Re-sign shared permit
+			const adaPermit = await reSignSharedPermit(bobPermitShared, ethers.provider, ada)
+			const adaPermission = extractPermissionV2(adaPermit)
+
+			// Expect not to revert
+			await counter1.connect(bob).getCounterPermitSealed(bobPermission)
+			await counter1.connect(ada).getCounterPermitSealed(adaPermission)
+
+			// BOB: Revoke id
+			const tx = await permissionRevokableValidator.connect(bob).revokeId(revokableId)
+			await tx.wait()
+
+			// Expect reversion
+			await expect(counter1.connect(bob).getCounterPermitSealed(bobPermission)).to.be.revertedWithCustomError(counter1, 'PermissionInvalid_Disabled')
+			await expect(counter1.connect(ada).getCounterPermitSealed(adaPermission)).to.be.revertedWithCustomError(counter1, 'PermissionInvalid_Disabled')
+		})
+
+		it('revokable via timestamp', async () => {
+			const { bob, ada, counter1, permissionTimestampValidator, permissionTimestampValidatorAddress } = await permissionedV2Fixture()
+
+			await counter1.connect(bob).add(await fhenixjs.encrypt_uint32(5))
+
+			// BOB: Timestamp to use as validator id
+			const timestamp = await getLastBlockTimestamp()
+
+			// BOB: Create sharable permit with validator
+			const bobPermitSelf = await generatePermitV2(
+				{
+					issuer: bob.address,
+					projects: ['COUNTER'],
+					validatorId: timestamp,
+					validatorContract: permissionTimestampValidatorAddress,
+				},
+				ethers.provider,
+				bob
+			)
+			const bobPermission = extractPermissionV2(bobPermitSelf)
+			const bobPermitShared = await generatePermitV2(
+				{
+					issuer: bob.address,
+					projects: ['COUNTER'],
+					validatorId: timestamp,
+					validatorContract: permissionTimestampValidatorAddress,
+					recipient: ada.address,
+				},
+				ethers.provider,
+				bob
+			)
+
+			// ADA: Re-sign shared permit
+			const adaPermit = await reSignSharedPermit(bobPermitShared, ethers.provider, ada)
+			const adaPermission = extractPermissionV2(adaPermit)
+
+			// Expect not to revert
+			await counter1.connect(bob).getCounterPermitSealed(bobPermission)
+			await counter1.connect(ada).getCounterPermitSealed(adaPermission)
+
+			// BOB: Update revoke before timestamp to revoke all existing permissions
+			const tx = await permissionTimestampValidator.connect(bob).revokeExisting()
+			await tx.wait()
+
+			// Just passing the time
+			await counter1.connect(bob).add(await fhenixjs.encrypt_uint32(5))
+			await counter1.connect(bob).add(await fhenixjs.encrypt_uint32(5))
+			await counter1.connect(bob).add(await fhenixjs.encrypt_uint32(5))
+			await counter1.connect(bob).add(await fhenixjs.encrypt_uint32(5))
+
+			// Expect reversion
+			await expect(counter1.connect(bob).getCounterPermitSealed(bobPermission)).to.be.revertedWithCustomError(counter1, 'PermissionInvalid_Disabled')
+			await expect(counter1.connect(ada).getCounterPermitSealed(adaPermission)).to.be.revertedWithCustomError(counter1, 'PermissionInvalid_Disabled')
+		})
+	})
+
+	// =================================
+	//               MISC
+	// =================================
+
+	describe('Misc', async () => {
+		it('`msg.sender` irrelevant to returned data', async () => {
+			const { signer, bob, ada, counter1, counter1Address } = await permissionedV2Fixture()
+
+			await counter1.connect(bob).add(await fhenixjs.encrypt_uint32(5))
+			await counter1.connect(ada).add(await fhenixjs.encrypt_uint32(3))
+
+			// Bob permission - accesses bob's data
+			const permit = await generatePermitV2(
+				{
+					issuer: bob.address,
+					contracts: [counter1Address],
+				},
+				ethers.provider,
+				bob
+			)
+			const permission = extractPermissionV2(permit)
+
+			const sealedNoSigner = await counter1.getCounterPermitSealed(permission)
+			expect(permit.sealingPair.unseal(sealedNoSigner)).to.eq(5, "No signer - Returns Bob's data")
+
+			const sealedBobSigner = await counter1.connect(bob).getCounterPermitSealed(permission)
+			expect(permit.sealingPair.unseal(sealedBobSigner)).to.eq(5, "Bob signer - Returns Bob's data")
+
+			const sealedAdaSigner = await counter1.connect(ada).getCounterPermitSealed(permission)
+			expect(permit.sealingPair.unseal(sealedAdaSigner)).to.eq(5, "Ada signer - Returns Bob's data")
+
+			const sealedSignerSigner = await counter1.connect(signer).getCounterPermitSealed(permission)
+			expect(permit.sealingPair.unseal(sealedSignerSigner)).to.eq(5, "Signer signer - Returns Bob's data")
+		})
+
+		it('checkPermissionSatisfies', async () => {
+			const { bob, counter1, counter1Address, counter2 } = await permissionedV2Fixture()
+
+			const permitCounter1Address = await generatePermitV2(
+				{
+					issuer: bob.address,
+					contracts: [counter1Address],
+				},
+				ethers.provider,
+				bob
+			)
+			const permissionCounter1Address = extractPermissionV2(permitCounter1Address)
+
+			expect(await counter1.checkPermissionSatisfies(permissionCounter1Address)).to.eq(true, 'Permission satisfies counter1 (`permission.contracts`)')
+			expect(await counter2.checkPermissionSatisfies(permissionCounter1Address)).to.eq(false, 'Permission does not satisfy counter2 (`permission.contracts`)')
+
+			const permitCounterProject = await generatePermitV2(
+				{
+					issuer: bob.address,
+					projects: ['COUNTER'],
+				},
+				ethers.provider,
+				bob
+			)
+			const permissionCounterProject = extractPermissionV2(permitCounterProject)
+
+			expect(await counter1.checkPermissionSatisfies(permissionCounterProject)).to.eq(true, 'Permission satisfies counter1 (`permission.projects`)')
+			expect(await counter2.checkPermissionSatisfies(permissionCounterProject)).to.eq(true, 'Permission satisfies counter2 (`permission.projects`)')
+
+			const permitUniswapProject = await generatePermitV2(
+				{
+					issuer: bob.address,
+					projects: ['UNISWAP'],
+				},
+				ethers.provider,
+				bob
+			)
+			const permissionUniswapProject = extractPermissionV2(permitUniswapProject)
+
+			expect(await counter1.checkPermissionSatisfies(permissionUniswapProject)).to.eq(false, 'Permission does not satisfy counter1 (`permission.projects`)')
+			expect(await counter2.checkPermissionSatisfies(permissionUniswapProject)).to.eq(false, 'Permission does not satisfy counter2 (`permission.projects`)')
+		})
+	})
+})

--- a/test/permitV2/chain-utils.ts
+++ b/test/permitV2/chain-utils.ts
@@ -1,0 +1,31 @@
+import hre from 'hardhat'
+
+export async function getTokensFromFaucet(address: string) {
+	if (hre.network.name === 'localfhenix') {
+		if ((await hre.ethers.provider.getBalance(address)).toString() === '0') {
+			await hre.fhenixjs.getFunds(address)
+		}
+	}
+}
+
+export const getLastBlockTimestamp = async () => {
+	return (await hre.ethers.provider.getBlock('latest'))!.timestamp
+}
+
+export const createExpiration = async (duration: number) => {
+	const timestamp = await getLastBlockTimestamp()
+	return timestamp + duration
+}
+
+// = Fhenix =
+export const unsealMockFheOpsSealed = (sealed: string): bigint => {
+	const byteArray = new Uint8Array(sealed.split('').map((c) => c.charCodeAt(0)))
+
+	// Step 2: Convert the Uint8Array to BigInt
+	let result = BigInt(0)
+	for (let i = 0; i < byteArray.length; i++) {
+		result = (result << BigInt(8)) + BigInt(byteArray[i]) // Shift and add each byte
+	}
+
+	return result
+}

--- a/test/permitV2/permit-v2-utils.ts
+++ b/test/permitV2/permit-v2-utils.ts
@@ -1,0 +1,224 @@
+import { ZeroAddress } from 'ethers'
+import { SealingKey, PermitSigner, EIP712Domain, EIP712Types, SupportedProvider, GenerateSealingKey } from 'fhenixjs'
+import { PermissionV2Struct } from '../../types/contracts/access/PermissionedV2.sol/PermissionedV2'
+
+type FhenixJsPermitV2 = {
+	issuer: string
+	expiration: number
+	contracts: string[]
+	projects: string[]
+	recipient: string
+	validatorId: number
+	validatorContract: string
+	sealingPair: SealingKey
+	issuerSignature: string
+	recipientSignature: string
+}
+
+const sign = async (signer: PermitSigner, domain: EIP712Domain, types: EIP712Types, value: object): Promise<string> => {
+	if ('_signTypedData' in signer && typeof signer._signTypedData == 'function') {
+		return await signer._signTypedData(domain, types, value)
+	} else if ('signTypedData' in signer && typeof signer.signTypedData == 'function') {
+		return await signer.signTypedData(domain, types, value)
+	}
+	throw new Error('Unsupported signer')
+}
+
+const determineRequestMethod = (provider: SupportedProvider): Function => {
+	if ('request' in provider && typeof provider.request === 'function') {
+		return (p: SupportedProvider, method: string, params?: unknown[]) =>
+			(p.request as ({ method, params }: { method: string; params?: unknown[] }) => Promise<unknown>)({ method, params })
+	} else if ('send' in provider && typeof provider.send === 'function') {
+		return (p: SupportedProvider, method: string, params?: unknown[]) => (p.send as (method: string, params?: unknown[]) => Promise<unknown>)(method, params)
+	} else {
+		throw new Error("Received unsupported provider. 'send' or 'request' method not found")
+	}
+}
+
+const determineRequestSigner = (provider: SupportedProvider): Function => {
+	if ('getSigner' in provider && typeof provider.getSigner === 'function') {
+		return (p: SupportedProvider) => (p.getSigner as () => unknown)()
+	} else {
+		throw new Error('The supplied provider cannot get a signer')
+	}
+}
+
+export const generatePermitV2 = async (
+	options: {
+		issuer: string
+		contracts?: string[]
+		projects?: string[]
+		expiration?: number
+		recipient?: string
+		validatorId?: number
+		validatorContract?: string
+	},
+	provider: SupportedProvider,
+	customSigner?: PermitSigner
+): Promise<FhenixJsPermitV2> => {
+	const {
+		issuer,
+		contracts = [],
+		projects = [],
+		expiration = 1000000000000,
+		recipient = ZeroAddress,
+		validatorId = 0,
+		validatorContract = ZeroAddress,
+	} = options
+
+	const isSharing = recipient !== ZeroAddress
+
+	if (!provider) {
+		throw new Error('Provider is undefined')
+	}
+
+	const requestMethod = determineRequestMethod(provider)
+
+	let signer: PermitSigner
+	if (!customSigner) {
+		const getSigner = determineRequestSigner(provider)
+		signer = await getSigner(provider)
+	} else {
+		signer = customSigner
+	}
+
+	const chainId = await requestMethod(provider, 'eth_chainId', [])
+
+	const keypair = await GenerateSealingKey()
+
+	let types: EIP712Types = {
+		PermissionedV2IssuerSelf: [
+			{ name: 'issuer', type: 'address' },
+			{ name: 'expiration', type: 'uint64' },
+			{ name: 'contracts', type: 'address[]' },
+			{ name: 'projects', type: 'string[]' },
+			{ name: 'recipient', type: 'address' },
+			{ name: 'validatorId', type: 'uint256' },
+			{ name: 'validatorContract', type: 'address' },
+			{ name: 'sealingKey', type: 'bytes32' },
+		],
+	}
+	let message: object = {
+		issuer,
+		sealingKey: `0x${keypair.publicKey}`,
+		expiration: expiration.toString(),
+		contracts,
+		projects,
+		recipient,
+		validatorId,
+		validatorContract,
+	}
+
+	if (isSharing) {
+		types = {
+			PermissionedV2IssuerShared: [
+				{ name: 'issuer', type: 'address' },
+				{ name: 'expiration', type: 'uint64' },
+				{ name: 'contracts', type: 'address[]' },
+				{ name: 'projects', type: 'string[]' },
+				{ name: 'recipient', type: 'address' },
+				{ name: 'validatorId', type: 'uint256' },
+				{ name: 'validatorContract', type: 'address' },
+			],
+		}
+		message = {
+			issuer,
+			expiration: expiration.toString(),
+			contracts,
+			projects,
+			recipient,
+			validatorId,
+			validatorContract,
+		}
+	}
+
+	const msgSig = await sign(
+		signer,
+		// Domain
+		{
+			name: 'Fhenix Permission v2.0.0',
+			version: 'v2.0.0',
+			chainId,
+			verifyingContract: ZeroAddress,
+		},
+		types,
+		message
+	)
+
+	const permit: FhenixJsPermitV2 = {
+		issuer,
+		expiration,
+		sealingPair: keypair,
+		contracts,
+		projects,
+		recipient: recipient,
+		validatorId,
+		validatorContract,
+		issuerSignature: msgSig,
+		recipientSignature: '0x',
+	}
+
+	return permit
+}
+
+export const reSignSharedPermit = async (
+	sharedPermit: FhenixJsPermitV2,
+	provider: SupportedProvider,
+	customSigner?: PermitSigner
+): Promise<FhenixJsPermitV2> => {
+	if (!provider) {
+		throw new Error('Provider is undefined')
+	}
+
+	const requestMethod = determineRequestMethod(provider)
+
+	let signer: PermitSigner
+	if (!customSigner) {
+		const getSigner = determineRequestSigner(provider)
+		signer = await getSigner(provider)
+	} else {
+		signer = customSigner
+	}
+
+	const chainId = await requestMethod(provider, 'eth_chainId', [])
+
+	const keypair = await GenerateSealingKey()
+
+	const recipientSignature = await sign(
+		signer,
+		// Domain
+		{
+			name: 'Fhenix Permission v2.0.0',
+			version: 'v2.0.0',
+			chainId,
+			verifyingContract: ZeroAddress,
+		},
+		// Types
+		{
+			PermissionedV2Recipient: [
+				{ name: 'sealingKey', type: 'bytes32' },
+				{ name: 'issuerSignature', type: 'bytes' },
+			],
+		},
+		// Message
+		{
+			sealingKey: `0x${keypair.publicKey}`,
+			issuerSignature: sharedPermit.issuerSignature,
+		}
+	)
+
+	const permit: FhenixJsPermitV2 = {
+		...sharedPermit,
+		sealingPair: keypair,
+		recipientSignature,
+	}
+
+	return permit
+}
+
+export const extractPermissionV2 = ({ sealingPair, ...permission }: FhenixJsPermitV2): PermissionV2Struct => {
+	return {
+		...permission,
+		sealingKey: `0x${sealingPair.publicKey}`,
+	}
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,3 +1,22 @@
 {
-    "moduleResolution": "NodeNext"
+	"compilerOptions": {
+		"declaration": true,
+		"declarationMap": true,
+		"emitDecoratorMetadata": true,
+		"esModuleInterop": true,
+		"experimentalDecorators": true,
+		"forceConsistentCasingInFileNames": true,
+		"lib": ["es2020"],
+		"module": "commonjs",
+		"moduleResolution": "node",
+		"noImplicitAny": true,
+		"removeComments": true,
+		"resolveJsonModule": true,
+		"sourceMap": true,
+		"strict": true,
+		"target": "es2020"
+	},
+	"exclude": ["node_modules"],
+	"files": ["./hardhat.config.ts"],
+	"include": ["contracts/**/*", "scripts/**/*", "test/**/*", "types/"]
 }


### PR DESCRIPTION
Stateless implementation of the PermitV2 spec found here: [SPEC](https://docs.google.com/document/d/17ZD1zq3CuCWKIc5Zqq91ywC3dd0GLhck6lJOy7mGNGU/edit#heading=h.5wf8re5w1jju)


This implementation allows a single permit to access the data of multiple contracts, has an in-built expiration mechanism, and can be shared without too much friction.

Additionally, users can customize and choose their own external validation. This can be leveraged to enable revoking of permits even after they have been shared.

Main contract: [`PermissionedV2.sol`](https://github.com/FhenixProtocol/fhenix-contracts/pull/85/files#diff-75a8fa0fd9f953371c5a39bbd94f87dc365f102ca2595884b0ab5cc4097db6c4)

I've added tests to [`PermissionedV2.test.ts`](https://github.com/FhenixProtocol/fhenix-contracts/pull/85/files#diff-587906783c354aee0e6c5e52114eab9f9b31a9a1ea2ee169dda05b97047d46b1), which uses `test/PermissionedV2Counter.sol` contract as a testbed. Going through the tests is probably the best way to see how the new system works, the tests have 100% coverage.


### Access

EIP712 has a `verifyingContract` field that is usually populated with `address(this)`. This is intended to eliminate replay attacks where a signature is used multiple times, in multiple contracts, or even on multiple chains. Because the `PermissionV2` struct has its own in-built access fields, `verifyingContract` has been set to `address(0)`. 

[Modified `EIP712.sol` contract inherited by `PermissionedV2.sol`](https://github.com/FhenixProtocol/fhenix-contracts/pull/85/files#diff-049c0d8933a3c6b4dcaf3e265c09a3bec7ec5908cc1cb4d59abdccdbcd3f241d)

`PermissionV2.contracts` is a list of contract addresses that this permit is authorized for.
`PermissionV2.projects` is a list of authorized project identifiers. Project identifiers are strings that can group contracts together. For example the project id `FHERC20` groups all FHERC20s together, so a permit with `FHERC20` in their `projects` list would have access to all encrypted token balances without needing to add the contract addresses individually.

### Signatures

Every field of the PermissionV2 struct has to be "covered" by a signature. If a field isn't folded into the signature, it could be changed before being used to access data without causing a reversion. This becomes difficult when the `issuer` of a permit wants to share that permit with `recipient`. This is solved by changing which fields are covered by the `issuerSignature` depending on whether the permission will be shared. If the permit isn't intended for sharing, the `issuer` includes their own `sealingKey` in the signature, else `recipient` will add the `sealingKey` and cover it with `recipientSignature`.

If `issuer` is creating a permission that ISN'T intended to be shared, `issuerSignature` is signed with the format:
`SIG< issuer, expiration, contracts, projects, recipient, validatorId, validatorContract, sealingKey >` and is ready to be used.


If `issuer` is creating a permission that IS meant to be shared with `recipient` they sign a signature with the format:
`SIG< issuer, expiration, contracts, projects, recipient, validatorId, validatorContract >`. Note that `sealingKey` is missing, and that `recipient` is populated with with the address of the user to give access to.

None of this information is sensitive, so `issuer` can send the PermissionV2 blob to `recipient` as cleartext (_Since it can be public, we may want to create an on-chain permission sharing feature as part of the dashboard down the road_). Once received, `recipient` adds their own `sealingKey`, and creates their `recipientSignature` with the format:
`SIG< sealingKey, issuerSignature >` which covers the newly added `sealingKey`.

The combination of the `issuerSignature` and `recipientSignature` means that every field is folded into a signature, independent of whether the permission will be shared or not.

### External validators

`validatorId` and `validatorContract` are optional and can be used together to 
increase security and control by disabling a permission after it has been created.
Useful when sharing permits to provide external access to sensitive data (eg auditors).

I've added a few toy examples of validator contracts here: [`PermissionedV2Validators.sol`](https://github.com/FhenixProtocol/fhenix-contracts/pull/85/files#diff-32631b4479bca498d62b71ab07430e1b3c4fa497e2e6381a89a3ac979693faa1)

The `/test` folder isn't included in the fhenix-contracts package.json so it wont be included in npm releases btw.