### PR TITLE
Discussion: use CTR encryption for mock FHE ops

### DIFF
--- a/contracts/test/PermissionedV2Counter.sol
+++ b/contracts/test/PermissionedV2Counter.sol
@@ -3,6 +3,7 @@ pragma solidity >=0.8.13 <0.9.0;
 
 import "../FHE.sol";
 import {PermissionedV2, PermissionV2} from "../access/PermissionedV2.sol";
+import "hardhat/console.sol";
 
 contract PermissionedV2Counter is PermissionedV2 {
     mapping(address => euint32) private userCounter;
@@ -30,6 +31,7 @@ contract PermissionedV2Counter is PermissionedV2 {
     function getCounterPermitSealed(
         PermissionV2 memory permission
     ) public view withPermission(permission) returns (string memory) {
+        console.log("trigger permit sealed");
         return
             FHE.sealoutput(
                 userCounter[permission.issuer],

--- a/contracts/utils/debug/MockFheOps.sol
+++ b/contracts/utils/debug/MockFheOps.sol
@@ -6,24 +6,265 @@ library Precompiles {
 }
 
 contract MockFheOps {
-    /*
-    FheUint8 = 0
-    FheUint16 = 1
-    FheUint32 = 2
-    FheUint64 = 3
-    FheUint128 = 4
-    FheUint256 = 5
-    FheInt8 = 6
-    FheInt16 = 7
-    FheInt32 = 8
-    FheInt64 = 9
-    FheInt128 = 10
-    FheInt256 = 11
-    FheAddress = 12
-    FheBool = 13
-    */
+    using CTR for uint8;
+    using CTR for uint256;
+    using CTR for bool;
+    using CTR for bytes;
+    using CTR for bytes32;
 
-    function maxValue(uint8 utype) public pure returns (uint256) {
+    function trivialEncrypt(
+        bytes memory input,
+        uint8 toType,
+        int32
+    ) external pure returns (bytes memory) {
+        uint256 result = input.bytesToUint() % toType.maxValue();
+        return result.ctrEncrypt();
+    }
+
+    function add(
+        uint8 utype,
+        bytes memory lhsHash,
+        bytes memory rhsHash
+    ) external pure returns (bytes memory) {
+        uint256 result = (lhsHash.ctrDecrypt() + rhsHash.ctrDecrypt()) % utype.maxValue();
+        return result.ctrEncrypt();
+    }
+
+    function sealOutput(
+        uint8,
+        bytes memory ctHash,
+        bytes memory pk
+    ) external pure returns (string memory) {
+        string memory result = ctHash.ctrSeal(pk);
+        return result;
+    }
+
+    function verify(
+        uint8,
+        bytes memory input,
+        int32
+    ) external pure returns (bytes memory) {
+        return input;
+    }
+
+    function cast(
+        uint8,
+        bytes memory input,
+        uint8 toType
+    ) external pure returns (bytes memory) {
+        uint256 result = input.ctrDecrypt() % toType.maxValue();
+        return result.ctrEncrypt();
+    }
+
+    function log(string memory s) external pure {}
+
+    function decrypt(
+        uint8,
+        bytes memory input,
+        uint256
+    ) external pure returns (uint256) {
+        return input.ctrDecrypt();
+    }
+
+    function lte(
+        uint8 utype,
+        bytes memory lhsHash,
+        bytes memory rhsHash
+    ) external pure returns (bytes memory) {
+        bool result = lhsHash.ctrDecrypt(utype) <= rhsHash.ctrDecrypt(utype);
+        return result.ctrEncrypt();
+    }
+
+    function sub(
+        uint8 utype,
+        bytes memory lhsHash,
+        bytes memory rhsHash
+    ) external pure returns (bytes memory) {
+        uint256 result = (lhsHash.ctrDecrypt() - rhsHash.ctrDecrypt()) % utype.maxValue();
+        return result.ctrEncrypt();
+    }
+
+    function mul(
+        uint8 utype,
+        bytes memory lhsHash,
+        bytes memory rhsHash
+    ) external pure returns (bytes memory) {
+        uint256 result = (lhsHash.ctrDecrypt() * rhsHash.ctrDecrypt()) % utype.maxValue();
+        return result.ctrEncrypt();
+    }
+
+    function lt(
+        uint8 utype,
+        bytes memory lhsHash,
+        bytes memory rhsHash
+    ) external pure returns (bytes memory) {
+        bool result = lhsHash.ctrDecrypt(utype) < rhsHash.ctrDecrypt(utype);
+        return result.ctrEncrypt();
+    }
+
+    function select(
+        uint8 utype,
+        bytes memory controlHash,
+        bytes memory ifTrueHash,
+        bytes memory ifFalseHash
+    ) external pure returns (bytes memory) {
+        bool control = controlHash.ctrDecrypt(utype) == 1 ? true : false;
+        return control ? ifTrueHash : ifFalseHash;
+    }
+
+    function req(
+        uint8 utype,
+        bytes memory input
+    ) external pure returns (bytes memory) {
+        require(input.ctrDecrypt(utype) != 0);
+        return input;
+    }
+
+    function div(
+        uint8 utype,
+        bytes memory lhsHash,
+        bytes memory rhsHash
+    ) external pure returns (bytes memory) {
+        uint256 result = (lhsHash.ctrDecrypt() / rhsHash.ctrDecrypt()) % utype.maxValue();
+        return result.ctrEncrypt();
+    }
+
+    function gt(
+        uint8 utype,
+        bytes memory lhsHash,
+        bytes memory rhsHash
+    ) external pure returns (bytes memory) {
+        bool result = lhsHash.ctrDecrypt(utype) > rhsHash.ctrDecrypt(utype);
+        return result.ctrEncrypt();
+    }
+
+    function gte(
+        uint8 utype,
+        bytes memory lhsHash,
+        bytes memory rhsHash
+    ) external pure returns (bytes memory) {
+        bool result = lhsHash.ctrDecrypt(utype) >= rhsHash.ctrDecrypt(utype);
+        return result.ctrEncrypt();
+    }
+
+    function rem(
+        uint8 utype,
+        bytes memory lhsHash,
+        bytes memory rhsHash
+    ) external pure returns (bytes memory) {
+        uint256 result = (lhsHash.ctrDecrypt() % rhsHash.ctrDecrypt()) % utype.maxValue();
+        return result.ctrEncrypt();
+    }
+
+    function and(
+        uint8 utype,
+        bytes memory lhsHash,
+        bytes memory rhsHash
+    ) external pure returns (bytes memory) {
+        bytes32 result = bytes32(lhsHash.ctrDecrypt(utype)) & bytes32(rhsHash.ctrDecrypt(utype));
+        return result.ctrEncrypt();
+    }
+
+    function or(
+        uint8 utype,
+        bytes memory lhsHash,
+        bytes memory rhsHash
+    ) external pure returns (bytes memory) {
+        bytes32 result = bytes32(lhsHash.ctrDecrypt(utype)) | bytes32(rhsHash.ctrDecrypt(utype));
+        return result.ctrEncrypt();
+    }
+
+    function xor(
+        uint8 utype,
+        bytes memory lhsHash,
+        bytes memory rhsHash
+    ) external pure returns (bytes memory) {
+        bytes32 result = bytes32(lhsHash.ctrDecrypt(utype)) ^ bytes32(rhsHash.ctrDecrypt(utype));
+        return result.ctrEncrypt();
+    }
+
+    function eq(
+        uint8 utype,
+        bytes memory lhsHash,
+        bytes memory rhsHash
+    ) external pure returns (bytes memory) {
+        bool result = lhsHash.ctrDecrypt(utype) == rhsHash.ctrDecrypt(utype);
+        return result.ctrEncrypt();
+    }
+
+    function ne(
+        uint8 utype,
+        bytes memory lhsHash,
+        bytes memory rhsHash
+    ) external pure returns (bytes memory) {
+        bool result = lhsHash.ctrDecrypt(utype) != rhsHash.ctrDecrypt(utype);
+        return result.ctrEncrypt();
+    }
+
+    function min(
+        uint8 utype,
+        bytes memory lhsHash,
+        bytes memory rhsHash
+    ) external pure returns (bytes memory) {
+        bool result = lhsHash.ctrDecrypt(utype) >= rhsHash.ctrDecrypt(utype);
+        return result ? rhsHash : lhsHash;
+    }
+
+    function max(
+        uint8 utype,
+        bytes memory lhsHash,
+        bytes memory rhsHash
+    ) external pure returns (bytes memory) {
+        bool result = lhsHash.ctrDecrypt(utype) >= rhsHash.ctrDecrypt(utype);
+        return result ? lhsHash : rhsHash;
+    }
+
+    function shl(
+        uint8 utype,
+        bytes memory lhsHash,
+        bytes memory rhsHash
+    ) external pure returns (bytes memory) {
+        uint256 result = lhsHash.ctrDecrypt(utype) << rhsHash.ctrDecrypt(utype);
+        return result.ctrEncrypt();
+    }
+
+    function shr(
+        uint8 utype,
+        bytes memory lhsHash,
+        bytes memory rhsHash
+    ) external pure returns (bytes memory) {
+        uint256 result = lhsHash.ctrDecrypt(utype) >> rhsHash.ctrDecrypt(utype);
+        return result.ctrEncrypt();
+    }
+
+    function not(
+        uint8 utype,
+        bytes memory value
+    ) external pure returns (bytes memory) {
+        bytes32 result = ~bytes32(value.ctrDecrypt(utype));
+        return result.ctrEncrypt();
+    }
+
+    function getNetworkPublicKey(int32) external pure returns (bytes memory) {
+        return CTR.key();
+    }
+
+    function random(
+        uint8 utype,
+        uint64,
+        int32
+    ) external view returns (bytes memory) {
+        uint256 result = uint256(keccak256(abi.encode(block.timestamp))) % utype.maxValue();
+        return result.ctrEncrypt();
+    }
+}
+
+library CTR {
+    function key() internal pure returns (bytes memory) {
+        return abi.encodePacked("deadbeef");
+    }
+
+    function maxValue(uint8 utype) internal pure returns (uint256) {
         uint256 result = 0;
         if (utype == 0) {
             result = uint256(type(uint8).max) + 1;
@@ -48,15 +289,104 @@ contract MockFheOps {
         return result;
     }
 
+    // CTR ENCRYPTION
+
+    // Mock encryption using CTR Encryption
+    // https://en.wikipedia.org/wiki/Block_cipher_mode_of_operation#Counter_(CTR)
+    // ctrSymmetricEncrypt(ctrSymmetricEncrypt(5, key), key) = 5
+    function ctrSymmetricEncrypt(
+        bytes memory data,
+        bytes memory _key
+    ) internal pure returns (bytes memory result) {
+        // Store data length on stack for later use
+        uint256 length = data.length;
+
+        assembly {
+            // Set result to free memory pointer
+            result := mload(0x40)
+            // Increase free memory pointer by length + 32
+            mstore(0x40, add(add(result, length), 32))
+            // Set result length
+            mstore(result, length)
+        }
+
+        // Iterate over the data stepping by 32 bytes
+        for (uint256 i = 0; i < length; i += 32) {
+
+        // Generate hash of the key and offset
+        bytes memory packed = abi.encodePacked(_key, i);
+        bytes32 hash = keccak256(packed);
+
+        bytes32 chunk;
+        assembly {
+            // Read 32-bytes data chunk
+            chunk := mload(add(data, add(i, 32)))
+        }
+        // XOR the chunk with hash
+        chunk ^= hash;
+        assembly {
+            // Write 32-byte encrypted chunk
+            mstore(add(result, add(i, 32)), chunk)
+        }
+        }
+    }
+    
+    function ctrEncrypt(
+        uint256 data
+    ) internal pure returns (bytes memory) {
+        return ctrSymmetricEncrypt(uint256ToBytes(data), key());
+    }
+
+    function ctrEncrypt(
+        bool data
+    ) internal pure returns (bytes memory) {
+        return ctrEncrypt(data ? 1 : 0);
+    }
+
+    function ctrEncrypt(
+        bytes memory data
+    ) internal pure returns (bytes memory) {
+        return ctrSymmetricEncrypt(data, key());
+    }
+
+    function ctrEncrypt(
+        bytes32 data
+    ) internal pure returns (bytes memory) {
+        return ctrSymmetricEncrypt(bytes32ToBytes(data), key());
+    }
+    
+    function ctrDecrypt(
+        bytes memory data
+    ) internal pure returns (uint256) {
+        return bytesToUint(ctrSymmetricEncrypt(data, key()));
+    }
+
+    function ctrDecrypt(
+        bytes memory data,
+        uint8 utype
+    ) internal pure returns (uint256) {
+        return ctrDecrypt(data) % maxValue(utype);
+    }
+
+    function ctrSeal(
+        bytes memory data,
+        bytes memory pk
+    ) internal pure returns (string memory) {
+        bytes memory decrypted = ctrSymmetricEncrypt(data, key());
+        bytes memory reencrypted = ctrSymmetricEncrypt(decrypted, pk);
+        return bytesToHexString(reencrypted);
+    }
+
+    // Conversion utils
+
     function bytes32ToBytes(
-        bytes32 input,
-        uint8
+        bytes32 input
     ) internal pure returns (bytes memory) {
         return bytes.concat(input);
     }
 
     //For converting back to bytes
-    function uint256ToBytes(uint256 value) public pure returns (bytes memory) {
+    function uint256ToBytes(uint256 value) internal pure returns (bytes memory) {
         bytes memory result = new bytes(32);
 
         assembly {
@@ -66,312 +396,27 @@ contract MockFheOps {
         return result;
     }
 
-    function boolToBytes(bool value) public pure returns (bytes memory) {
-        bytes memory result = new bytes(1);
-
-        if (value) {
-            result[0] = 0x01;
-        } else {
-            result[0] = 0x00;
-        }
-
-        return result;
-    }
-
     //for unknown size of bytes - we could instead just encode it as bytes32 because it's always uint256 but for now lets keep it like this
     function bytesToUint(
         bytes memory b
-    ) internal pure virtual returns (uint256) {
+    ) internal pure returns (uint256) {
         require(b.length <= 32, "Bytes length exceeds 32.");
-        return
-            abi.decode(
-                abi.encodePacked(new bytes(32 - b.length), b),
-                (uint256)
-            );
+        return abi.decode(
+            abi.encodePacked(new bytes(32 - b.length), b),
+            (uint256)
+        );
     }
 
-    function bytesToBool(bytes memory b) internal pure virtual returns (bool) {
-        require(b.length <= 32, "Bytes length exceeds 32.");
-        uint8 value = uint8(b[0]);
-        return value != 0;
-    }
+    function bytesToHexString(bytes memory data) public pure returns (string memory) {
+        bytes memory converted = new bytes(data.length * 2);
 
-    function trivialEncrypt(
-        bytes memory input,
-        uint8 toType,
-        int32
-    ) external pure returns (bytes memory) {
-        bytes32 result = bytes32(input);
-        return bytes32ToBytes(result, toType);
-    }
+        bytes memory _base = "0123456789abcdef";
 
-    function add(
-        uint8 utype,
-        bytes memory lhsHash,
-        bytes memory rhsHash
-    ) external pure returns (bytes memory) {
-        uint256 result = (bytesToUint(lhsHash) + bytesToUint(rhsHash)) %
-            maxValue(utype);
-        return uint256ToBytes(result);
-    }
-
-    function sealOutput(
-        uint8,
-        bytes memory ctHash,
-        bytes memory
-    ) external pure returns (string memory) {
-        return string(ctHash);
-    }
-
-    function verify(
-        uint8,
-        bytes memory input,
-        int32
-    ) external pure returns (bytes memory) {
-        return input;
-    }
-
-    function cast(
-        uint8,
-        bytes memory input,
-        uint8 toType
-    ) external pure returns (bytes memory) {
-        bytes32 result = bytes32(input);
-        return bytes32ToBytes(result, toType);
-    }
-
-    function log(string memory s) external pure {}
-
-    function decrypt(
-        uint8,
-        bytes memory input,
-        uint256
-    ) external pure returns (uint256) {
-        uint256 result = bytesToUint(input);
-        return result;
-    }
-
-    function lte(
-        uint8 utype,
-        bytes memory lhsHash,
-        bytes memory rhsHash
-    ) external pure returns (bytes memory) {
-        bool result = (bytesToUint(lhsHash) % maxValue(utype)) <=
-            (bytesToUint(rhsHash) % maxValue(utype));
-        return boolToBytes(result);
-    }
-
-    function sub(
-        uint8 utype,
-        bytes memory lhsHash,
-        bytes memory rhsHash
-    ) external pure returns (bytes memory) {
-        uint256 result = (bytesToUint(lhsHash) - bytesToUint(rhsHash)) %
-            maxValue(utype);
-        return uint256ToBytes(result);
-    }
-
-    function mul(
-        uint8 utype,
-        bytes memory lhsHash,
-        bytes memory rhsHash
-    ) external pure returns (bytes memory) {
-        uint256 result = (bytesToUint(lhsHash) * bytesToUint(rhsHash)) %
-            maxValue(utype);
-        return uint256ToBytes(result);
-    }
-
-    function lt(
-        uint8 utype,
-        bytes memory lhsHash,
-        bytes memory rhsHash
-    ) external pure returns (bytes memory) {
-        bool result = (bytesToUint(lhsHash) % maxValue(utype)) <
-            (bytesToUint(rhsHash) % maxValue(utype));
-        return boolToBytes(result);
-    }
-
-    function select(
-        uint8,
-        bytes memory controlHash,
-        bytes memory ifTrueHash,
-        bytes memory ifFalseHash
-    ) external pure returns (bytes memory) {
-        bool control = bytesToBool(controlHash);
-        if (control) return ifTrueHash;
-        return ifFalseHash;
-    }
-
-    function req(
-        uint8,
-        bytes memory input
-    ) external pure returns (bytes memory) {
-        bool condition = (bytesToUint(input) != 0);
-        require(condition);
-        return input;
-    }
-
-    function div(
-        uint8 utype,
-        bytes memory lhsHash,
-        bytes memory rhsHash
-    ) external pure returns (bytes memory) {
-        uint256 result = (bytesToUint(lhsHash) / bytesToUint(rhsHash)) %
-            maxValue(utype);
-        return uint256ToBytes(result);
-    }
-
-    function gt(
-        uint8 utype,
-        bytes memory lhsHash,
-        bytes memory rhsHash
-    ) external pure returns (bytes memory) {
-        bool result = (bytesToUint(lhsHash) % maxValue(utype)) >
-            (bytesToUint(rhsHash) % maxValue(utype));
-        return boolToBytes(result);
-    }
-
-    function gte(
-        uint8 utype,
-        bytes memory lhsHash,
-        bytes memory rhsHash
-    ) external pure returns (bytes memory) {
-        bool result = (bytesToUint(lhsHash) % maxValue(utype)) >=
-            (bytesToUint(rhsHash) % maxValue(utype));
-        return boolToBytes(result);
-    }
-
-    function rem(
-        uint8 utype,
-        bytes memory lhsHash,
-        bytes memory rhsHash
-    ) external pure returns (bytes memory) {
-        uint256 result = (bytesToUint(lhsHash) % bytesToUint(rhsHash)) %
-            maxValue(utype);
-        return uint256ToBytes(result);
-    }
-
-    function and(
-        uint8 utype,
-        bytes memory lhsHash,
-        bytes memory rhsHash
-    ) external pure returns (bytes memory) {
-        bytes32 result = bytes32(lhsHash) & bytes32(rhsHash);
-        return bytes32ToBytes(result, utype);
-    }
-
-    function or(
-        uint8 utype,
-        bytes memory lhsHash,
-        bytes memory rhsHash
-    ) external pure returns (bytes memory) {
-        bytes32 result = bytes32(lhsHash) | bytes32(rhsHash);
-        return bytes32ToBytes(result, utype);
-    }
-
-    function xor(
-        uint8 utype,
-        bytes memory lhsHash,
-        bytes memory rhsHash
-    ) external pure returns (bytes memory) {
-        bytes32 result = bytes32(lhsHash) ^ bytes32(rhsHash);
-        return bytes32ToBytes(result, utype);
-    }
-
-    function eq(
-        uint8 utype,
-        bytes memory lhsHash,
-        bytes memory rhsHash
-    ) external pure returns (bytes memory) {
-        bool result = (bytesToUint(lhsHash) % maxValue(utype)) ==
-            (bytesToUint(rhsHash) % maxValue(utype));
-        return boolToBytes(result);
-    }
-
-    function ne(
-        uint8 utype,
-        bytes memory lhsHash,
-        bytes memory rhsHash
-    ) external pure returns (bytes memory) {
-        bool result = (bytesToUint(lhsHash) % maxValue(utype)) !=
-            (bytesToUint(rhsHash) % maxValue(utype));
-        return boolToBytes(result);
-    }
-
-    function min(
-        uint8 utype,
-        bytes memory lhsHash,
-        bytes memory rhsHash
-    ) external pure returns (bytes memory) {
-        bool result = (bytesToUint(lhsHash) % maxValue(utype)) >=
-            (bytesToUint(rhsHash) % maxValue(utype));
-        if (result == true) {
-            return rhsHash;
+        for (uint256 i = 0; i < data.length; i++) {
+            converted[i * 2] = _base[uint8(data[i]) / _base.length];
+            converted[i * 2 + 1] = _base[uint8(data[i]) % _base.length];
         }
-        return lhsHash;
-    }
 
-    function max(
-        uint8 utype,
-        bytes memory lhsHash,
-        bytes memory rhsHash
-    ) external pure returns (bytes memory) {
-        bool result = (bytesToUint(lhsHash) % maxValue(utype)) >=
-            (bytesToUint(rhsHash) % maxValue(utype));
-        if (result == true) {
-            return lhsHash;
-        }
-        return rhsHash;
-    }
-
-    function shl(
-        uint8,
-        bytes memory lhsHash,
-        bytes memory rhsHash
-    ) external pure returns (bytes memory) {
-        uint256 lhs = bytesToUint(lhsHash);
-        uint256 rhs = bytesToUint(rhsHash);
-
-        uint256 result = lhs << rhs;
-
-        return uint256ToBytes(result);
-    }
-
-    function shr(
-        uint8,
-        bytes memory lhsHash,
-        bytes memory rhsHash
-    ) external pure returns (bytes memory) {
-        uint256 lhs = bytesToUint(lhsHash);
-        uint256 rhs = bytesToUint(rhsHash);
-
-        uint256 result = lhs >> rhs;
-
-        return uint256ToBytes(result);
-    }
-
-    function not(
-        uint8 utype,
-        bytes memory value
-    ) external pure returns (bytes memory) {
-        bytes32 result = ~bytes32(value);
-        return bytes32ToBytes(result, utype);
-    }
-
-    function getNetworkPublicKey(int32) external pure returns (bytes memory) {
-        string
-            memory x = "((-(-_(-_-)_-)-)) You've stepped into the wrong neighborhood pal.";
-        return bytes(x);
-    }
-
-    function random(
-        uint8 utype,
-        uint64,
-        int32
-    ) external view returns (bytes memory) {
-        return
-            uint256ToBytes(
-                uint(keccak256(abi.encode(block.timestamp))) % maxValue(utype)
-            );
+        return string(abi.encodePacked("0x", converted));
     }
 }

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -6,6 +6,7 @@ require('@nomiclabs/hardhat-truffle5')
 require('hardhat-exposed')
 import '@nomicfoundation/hardhat-ethers'
 import 'fhenix-hardhat-plugin'
+import './tasks/injectMockFheOps'
 
 const config = {
 	defaultNetwork: 'localfhenix',

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
 	"scripts": {
 		"docgen": "hardhat docgen",
 		"compile": "hardhat compile",
-		"test": "hardhat test"
+		"test": "hardhat test",
+		"test:hardhat": "hardhat test --network hardhat"
 	},
 	"files": [
 		"contracts"
@@ -36,8 +37,8 @@
 		"@types/mocha": "^10.0.6",
 		"chai": "^4.3.7",
 		"ethers": "^6.11.1",
-		"fhenix-hardhat-docker": "0.3.0-alpha.2",
-		"fhenix-hardhat-plugin": "0.3.0-alpha.2",
+		"fhenix-hardhat-docker": "0.3.2",
+		"fhenix-hardhat-plugin": "0.3.2",
 		"fhenixjs": "0.4.0-alpha.6",
 		"hardhat-exposed": "^0.3.13",
 		"hardhat": "2.19.3",
@@ -45,6 +46,7 @@
 		"solidity-docgen": "0.6.0-beta.36",
 		"ts-node": "^10.9.2",
 		"typechain": "^8.3.2",
-		"typescript": "^5.5.4"
+		"typescript": "^5.5.4",
+		"chalk": "^4.1.2"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,15 +41,18 @@ importers:
       chai:
         specifier: ^4.3.7
         version: 4.4.1
+      chalk:
+        specifier: ^4.1.2
+        version: 4.1.2
       ethers:
         specifier: ^6.11.1
         version: 6.13.1(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       fhenix-hardhat-docker:
-        specifier: 0.3.0-alpha.2
-        version: 0.3.0-alpha.2(hardhat@2.19.3(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@20.17.6)(typescript@5.5.4))(typescript@5.5.4)(utf-8-validate@5.0.10))
+        specifier: 0.3.2
+        version: 0.3.2(hardhat@2.19.3(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@20.17.6)(typescript@5.5.4))(typescript@5.5.4)(utf-8-validate@5.0.10))
       fhenix-hardhat-plugin:
-        specifier: 0.3.0-alpha.2
-        version: 0.3.0-alpha.2(bufferutil@4.0.8)(hardhat@2.19.3(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@20.17.6)(typescript@5.5.4))(typescript@5.5.4)(utf-8-validate@5.0.10))(utf-8-validate@5.0.10)
+        specifier: 0.3.2
+        version: 0.3.2(bufferutil@4.0.8)(hardhat@2.19.3(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@20.17.6)(typescript@5.5.4))(typescript@5.5.4)(utf-8-validate@5.0.10))(utf-8-validate@5.0.10)
       fhenixjs:
         specifier: 0.4.0-alpha.6
         version: 0.4.0-alpha.6
@@ -1558,18 +1561,22 @@ packages:
   fastq@1.17.1:
     resolution: {integrity: sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==}
 
-  fhenix-hardhat-docker@0.3.0-alpha.2:
-    resolution: {integrity: sha512-mAV15OcYJEjDpOCufZurNv7y/0LMsGA6IOhcSlH/77NIl6ZBT6mUyWKlZNyXpuh+/el/i5xCUQfRnRAh55FVTg==}
+  fhenix-hardhat-docker@0.3.2:
+    resolution: {integrity: sha512-fqPzwt0EqxvVg5hr1LVJ8BKyvQeOFITWv+ieyQMtd0o4DYobKUw6g3t4o9OKMs4eT+V8/lAyGFjDLxD2BBRKhA==}
     peerDependencies:
-      hardhat: ^2.0.0
+      hardhat: ^2.11.0
 
-  fhenix-hardhat-plugin@0.3.0-alpha.2:
-    resolution: {integrity: sha512-/9tmEfZab2G65kQvitR1shH9KUzmMNXN+sXtX9jDSI8QiIzrb2d7jRJP7B5B0ps8/arfPsegO3jm4mDj6CpOEg==}
+  fhenix-hardhat-plugin@0.3.2:
+    resolution: {integrity: sha512-cH1rONJv8OKE+nKu/iViLyLsGHfAKuE1z+rMPFdPuDkFjzmeWEMF6qsQgjjrzrG9PuksRU3rAzuhsadCKp4Fmw==}
     peerDependencies:
-      hardhat: ^2.0.0
+      hardhat: ^2.11.0
 
   fhenixjs@0.4.0-alpha.6:
     resolution: {integrity: sha512-pFXw0nEsK9nf3dMUz+N2fMbHiknDlllEiKJpTqNKNwBuJSmkw3aBOGJ6zVZcWfKxL0/5Pv+nfDfcAmyRwUQNnA==}
+    engines: {node: '>=20.0.0'}
+
+  fhenixjs@0.4.1:
+    resolution: {integrity: sha512-q+IgMHFhTrXpsdrDox67Qw4InffCPYiNnXpn8cUThmfKMLGOhVzp4TgMc4xG5yajVroIw+Fle1C8SJILxG+BVQ==}
     engines: {node: '>=20.0.0'}
 
   fill-range@7.0.1:
@@ -5848,17 +5855,17 @@ snapshots:
     dependencies:
       reusify: 1.0.4
 
-  fhenix-hardhat-docker@0.3.0-alpha.2(hardhat@2.19.3(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@20.17.6)(typescript@5.5.4))(typescript@5.5.4)(utf-8-validate@5.0.10)):
+  fhenix-hardhat-docker@0.3.2(hardhat@2.19.3(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@20.17.6)(typescript@5.5.4))(typescript@5.5.4)(utf-8-validate@5.0.10)):
     dependencies:
       chalk: 4.1.2
       hardhat: 2.19.3(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@20.17.6)(typescript@5.5.4))(typescript@5.5.4)(utf-8-validate@5.0.10)
 
-  fhenix-hardhat-plugin@0.3.0-alpha.2(bufferutil@4.0.8)(hardhat@2.19.3(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@20.17.6)(typescript@5.5.4))(typescript@5.5.4)(utf-8-validate@5.0.10))(utf-8-validate@5.0.10):
+  fhenix-hardhat-plugin@0.3.2(bufferutil@4.0.8)(hardhat@2.19.3(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@20.17.6)(typescript@5.5.4))(typescript@5.5.4)(utf-8-validate@5.0.10))(utf-8-validate@5.0.10):
     dependencies:
       axios: 1.7.2
       chalk: 4.1.2
       ethers: 6.13.1(bufferutil@4.0.8)(utf-8-validate@5.0.10)
-      fhenixjs: 0.4.0-alpha.6
+      fhenixjs: 0.4.1
       hardhat: 2.19.3(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@20.17.6)(typescript@5.5.4))(typescript@5.5.4)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - bufferutil
@@ -5866,6 +5873,12 @@ snapshots:
       - utf-8-validate
 
   fhenixjs@0.4.0-alpha.6:
+    dependencies:
+      '@types/node': 20.17.6
+      tweetnacl: 1.0.3
+      tweetnacl-util: 0.15.1
+
+  fhenixjs@0.4.1:
     dependencies:
       '@types/node': 20.17.6
       tweetnacl: 1.0.3

--- a/tasks/injectMockFheOps.ts
+++ b/tasks/injectMockFheOps.ts
@@ -1,0 +1,20 @@
+import chalk from 'chalk'
+import { HardhatRuntimeEnvironment } from 'hardhat/types'
+import { TASK_TEST } from 'hardhat/builtin-tasks/task-names'
+import { HARDHAT_NETWORK_NAME } from 'hardhat/plugins'
+import { task } from 'hardhat/config'
+
+export const injectFhenixMocks = async (hre: HardhatRuntimeEnvironment) => {
+	if (hre.network.name === HARDHAT_NETWORK_NAME) {
+		const MockFheOpsArtifact = await hre.artifacts.readArtifact('MockFheOps')
+
+		await hre.network.provider.send('hardhat_setCode', ['0x0000000000000000000000000000000000000080', MockFheOpsArtifact.deployedBytecode])
+
+		console.log(chalk.bold(chalk.green('fhenix-hardhat-network - Using mocked FHE on Hardhat network')))
+	}
+}
+
+task(TASK_TEST, 'Deploy fhenix mock contracts into test hardhat runner').setAction(async ({}, hre: HardhatRuntimeEnvironment, runSuper) => {
+	await injectFhenixMocks(hre)
+	return runSuper()
+})

--- a/test/mock-fhe-ops.ts
+++ b/test/mock-fhe-ops.ts
@@ -1,0 +1,28 @@
+import { ethers } from 'hardhat'
+
+import { MockFheOps__factory } from '../types'
+import { getTokensFromFaucet } from './permitV2/chain-utils'
+
+describe('MockFheOps', function () {
+	async function mockFheOpsFixture() {
+		const signer = (await ethers.getSigners())[0]
+
+		await getTokensFromFaucet(signer.address)
+
+		const mockFheOpsFactory = (await ethers.getContractFactory('MockFheOps')) as MockFheOps__factory
+		const ops = await mockFheOpsFactory.deploy()
+		await ops.waitForDeployment()
+		const opsAddress = await ops.getAddress()
+
+		return {
+			signer,
+			ops,
+		}
+	}
+
+	it('deploy', async () => {
+		const { ops } = await mockFheOpsFixture()
+
+		console.log({ ops })
+	})
+})

--- a/test/permitV2/permit-v2-utils.ts
+++ b/test/permitV2/permit-v2-utils.ts
@@ -82,7 +82,7 @@ export const generatePermitV2 = async (
 		signer = customSigner
 	}
 
-	const chainId = await requestMethod(provider, 'eth_chainId', [])
+	const chainId = parseInt(await requestMethod(provider, 'eth_chainId', []))
 
 	const keypair = await GenerateSealingKey()
 
@@ -105,7 +105,7 @@ export const generatePermitV2 = async (
 		contracts,
 		projects,
 		recipient,
-		validatorId,
+		validatorId: `${validatorId}`,
 		validatorContract,
 	}
 

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1,0 +1,24 @@
+import { getBytes, hexlify, solidityPacked, solidityPackedKeccak256 } from 'ethers'
+
+export function ctrSymmetricEncrypt(data: string, key: string): string {
+	const dataBytes = getBytes(data) // Ensure data is in byte format
+
+	const length = dataBytes.length
+	const resultBytes: Uint8Array = new Uint8Array(length)
+
+	for (let i = 0; i < length; i += 32) {
+		const hash = solidityPackedKeccak256(['bytes', 'uint256'], [key, i])
+		const hashBytes = getBytes(hash)
+
+		// XOR data chunk with the hash chunk
+		for (let j = 0; j < 32 && i + j < length; j++) {
+			resultBytes[i + j] = dataBytes[i + j] ^ hashBytes[j]
+		}
+	}
+
+	return hexlify(resultBytes) // Convert the result back to a hex string
+}
+
+export function ctrKey() {
+	return solidityPacked(['string'], ['deadbeef'])
+}


### PR DESCRIPTION
Adds a symmetric encryption to `MockFheOps.sol`. This allows the mock ops to use encrypted values through the pipeline, and allows better testing of things like sealing, and makes the `euint___` variables opaque instead of cleartext. Its a step towards making the hardhat mocks as similar as possible to the real chain. With the new `fhenixsdk` which handles the PermitV2 stuff, this is very easy to update in the clients too.

```solidity
    // https://en.wikipedia.org/wiki/Block_cipher_mode_of_operation#Counter_(CTR)
    // ctrSymmetricEncrypt(ctrSymmetricEncrypt(5, key), key) = 5
    function ctrSymmetricEncrypt(
        bytes memory data,
        bytes memory _key
    ) internal pure returns (bytes memory result) {
        // Store data length on stack for later use
        uint256 length = data.length;

        assembly {
            // Set result to free memory pointer
            result := mload(0x40)
            // Increase free memory pointer by length + 32
            mstore(0x40, add(add(result, length), 32))
            // Set result length
            mstore(result, length)
        }

        // Iterate over the data stepping by 32 bytes
        for (uint256 i = 0; i < length; i += 32) {

        // Generate hash of the key and offset
        bytes memory packed = abi.encodePacked(_key, i);
        bytes32 hash = keccak256(packed);

        bytes32 chunk;
        assembly {
            // Read 32-bytes data chunk
            chunk := mload(add(data, add(i, 32)))
        }
        // XOR the chunk with hash
        chunk ^= hash;
        assembly {
            // Write 32-byte encrypted chunk
            mstore(add(result, add(i, 32)), chunk)
        }
        }
    }
    ```
    
    Do you guys think this is worthwhile to explore?