### PR TITLE
chore: fixed dead link in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Solidity contracts for working with FHE smart contract on Fhenix.
 
 Need help getting started? Check out the [fhenix documentation](https://docs.fhenix.io)!
 
-These contracts are still under heavy constructions and will be changing frequently. Consider binding your contracts to a specific version, and keep an eye on the [changelog](https://github.com/FhenixProtocol/fhenix-contracts/CHANGELOG.md)
+These contracts are still under heavy constructions and will be changing frequently. Consider binding your contracts to a specific version, and keep an eye on the [changelog](https://github.com/FhenixProtocol/fhenix-contracts/blob/main/CHANGELOG.md)
 
 ## Install
 


### PR DESCRIPTION
Hi! I fixed a dead link to the `CHANGELOG.md` file in the project `README`. The original link was missing the `/blob/main/` path segment, causing it to return a 404 error.