### PR TITLE
Validate FHE precompile output length

### DIFF
--- a/contracts/FHE.sol
+++ b/contracts/FHE.sol
@@ -79,6 +79,8 @@ struct SealedAddress {
 
 
 library Common {
+    error InvalidPrecompileOutput();
+
     // Values used to communicate types to the runtime.
     // Must match values defined in warp-drive protobufs for everything to 
     // make sense
@@ -128,6 +130,16 @@ library Common {
         b = new bytes(32);
         assembly { mstore(add(b, 32), x) }
     }
+
+    function getValue(bytes memory a) internal pure returns (uint256 value) {
+        if (a.length < 32) {
+            revert InvalidPrecompileOutput();
+        }
+
+        assembly {
+            value := mload(add(a, 0x20))
+        }
+    }
 }
 
 library Impl {
@@ -155,9 +167,7 @@ library Impl {
     }
 
     function getValue(bytes memory a) internal pure returns (uint256 value) {
-        assembly {
-            value := mload(add(a, 0x20))
-        }
+        return Common.getValue(a);
     }
 
     function trivialEncrypt(uint256 value, uint8 toType, int32 securityZone) internal pure returns (uint256 result) {
@@ -224,9 +234,7 @@ library FHE {
     }
 
     function getValue(bytes memory a) private pure returns (uint256 value) {
-        assembly {
-            value := mload(add(a, 0x20))
-        }
+        return Common.getValue(a);
     }
     
     function mathHelper(

--- a/contracts/test/FheValueDecoderTest.sol
+++ b/contracts/test/FheValueDecoderTest.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.13 <0.9.0;
+
+import {Common} from "../FHE.sol";
+
+contract FheValueDecoderTest {
+    function decode(bytes memory output) public pure returns (uint256) {
+        return Common.getValue(output);
+    }
+}

--- a/test/fhe/precompileOutput.ts
+++ b/test/fhe/precompileOutput.ts
@@ -1,0 +1,16 @@
+import { expect } from 'chai'
+import { ethers } from 'hardhat'
+
+describe('FHE precompile output decoding', function () {
+	it('decodes a 32-byte output word', async () => {
+		const decoder = await ethers.deployContract('FheValueDecoderTest')
+
+		expect(await decoder.decode(ethers.toBeHex(42, 32))).to.eq(42)
+	})
+
+	it('reverts when the output is shorter than one word', async () => {
+		const decoder = await ethers.deployContract('FheValueDecoderTest')
+
+		await expect(decoder.decode('0x1234')).to.be.revertedWithCustomError(decoder, 'InvalidPrecompileOutput')
+	})
+})


### PR DESCRIPTION
## Summary
- add a shared decoder for FHE precompile output words
- revert with InvalidPrecompileOutput when the returned bytes are shorter than 32 bytes
- route the existing Impl and FHE getValue helpers through the guarded decoder
- add focused coverage for valid and short precompile output bytes

Closes #124

## Testing
- pnpm compile
- pnpm hardhat test test/fhe/precompileOutput.ts --network hardhat

Note: Hardhat prints a Node.js v24 unsupported-version warning locally, but compile and the focused test both pass.