### PR TITLE
fix(FHERC20): make _transferEncrypted and _transferFromEncrypted internal

### DIFF
--- a/contracts/experimental/token/FHERC20/FHERC20.sol
+++ b/contracts/experimental/token/FHERC20/FHERC20.sol
@@ -63,7 +63,7 @@ contract FHERC20 is IFHERC20, ERC20, Permissioned {
         return _transferFromEncrypted(from, to, FHE.asEuint128(value));
     }
 
-    function _transferFromEncrypted(address from, address to, euint128 value) public virtual returns (euint128) {
+    function _transferFromEncrypted(address from, address to, euint128 value) internal virtual returns (euint128) {
         euint128 val = value;
         euint128 spent = _spendAllowance(from, msg.sender, val);
         return _transferImpl(from, to, spent);
@@ -106,7 +106,7 @@ contract FHERC20 is IFHERC20, ERC20, Permissioned {
     }
 
     // Transfers an amount from the message sender address to the `to` address.
-    function _transferEncrypted(address to, euint128 amount) public returns (euint128) {
+    function _transferEncrypted(address to, euint128 amount) internal returns (euint128) {
         return _transferImpl(msg.sender, to, amount);
     }
 


### PR DESCRIPTION
## Summary

Closes #126.

Both `_transferEncrypted` and `_transferFromEncrypted` were declared `public`, allowing external callers to pass raw `euint128` handles directly and bypass the ciphertext-verification step performed by `FHE.asEuint128(inEuint128)` in the public entrypoints.

## Changes

- `_transferEncrypted(address to, euint128 amount)` — changed `public` → `internal`
- `_transferFromEncrypted(address from, address to, euint128 value)` — changed `public virtual` → `internal virtual`

The externally validated entrypoints `transferEncrypted` and `transferFromEncrypted` remain `public` and continue to call these helpers after calling `FHE.asEuint128(inEuint128)` to verify and convert user-supplied ciphertext bytes.

## Why this matters

With `public` visibility, an attacker could call `_transferFromEncrypted` directly with a malformed or foreign `euint128` handle, skipping ciphertext validation entirely. This could lead to FHE precompile reverts that break multicall batches, or — if the runtime does not strictly bind handles — allow operations on attacker-influenced ciphertext values.