### PR TITLE
fix(FHE): validate precompile return length in getValue

### DIFF
--- a/contracts/FHE.sol
+++ b/contracts/FHE.sol
@@ -155,6 +155,7 @@ library Impl {
     }
 
     function getValue(bytes memory a) internal pure returns (uint256 value) {
+        require(a.length >= 32, "FHE: precompile returned insufficient bytes");
         assembly {
             value := mload(add(a, 0x20))
         }
@@ -224,6 +225,7 @@ library FHE {
     }
 
     function getValue(bytes memory a) private pure returns (uint256 value) {
+        require(a.length >= 32, "FHE: precompile returned insufficient bytes");
         assembly {
             value := mload(add(a, 0x20))
         }


### PR DESCRIPTION
## Summary

Closes #124.

Both `Impl.getValue` and the private `FHE.getValue` would unconditionally `mload` the first 32-byte word from bytes returned by the FHEOS precompile without checking the buffer length first. If the precompile ever returns a short or empty bytes slice (instead of reverting on error), the function silently reads arbitrary memory and wraps it as a ciphertext handle.

## Changes

Added `require(a.length >= 32, "FHE: precompile returned insufficient bytes")` before the assembly block in both `getValue` overloads:

```solidity
// Before (internal)
function getValue(bytes memory a) internal pure returns (uint256 value) {
    assembly {
        value := mload(add(a, 0x20));
    }
}

// After (internal)
function getValue(bytes memory a) internal pure returns (uint256 value) {
    require(a.length >= 32, "FHE: precompile returned insufficient bytes");
    assembly {
        value := mload(add(a, 0x20));
    }
}
```

The same guard is applied to the `private` overload in the `FHE` library.

## Why this matters

A buggy or adversarially modified FHEOS precompile could signal failure by returning empty bytes rather than reverting. Without the length check, the library wraps whatever word happens to be in memory as a valid ciphertext handle. With this fix, all callpaths fail explicitly and immediately with a clear error message.