### PR TITLE
fix(MockFheOps): set FheBool maxValue to 2 instead of 1

### DIFF
--- a/contracts/utils/debug/MockFheOps.sol
+++ b/contracts/utils/debug/MockFheOps.sol
@@ -40,7 +40,7 @@ contract MockFheOps {
         } else if (utype == 12) {
             result = uint256(type(uint160).max) + 1; //address
         } else if (utype == 13) {
-            result = 1; //bool (we want anything non-zero to be true)
+            result = 2; //bool (values 0 or 1; modulo 2 ensures non-zero results are possible)
         } else {
             revert("Unsupported type");
         }


### PR DESCRIPTION
## Summary

Closes #83.

`MockFheOps.maxValue()` returned `1` for `FheBool` (utype `13`), so every FHE boolean operation computed `result % 1 == 0` regardless of operands — effectively making all mock boolean results constantly zero.

## Change

```solidity
// Before
} else if (utype == 13) {
    result = 1; //bool (we want anything non-zero to be true)
}

// After
} else if (utype == 13) {
    result = 2; //bool (values 0 or 1; modulo 2 ensures non-zero results are possible)
}
```

## Why this matters

With `maxValue = 1`, `trivialEncrypt(value, FheBool) % 1 == 0` always. This means every encrypted boolean in the mock environment evaluates to `false`, making it impossible to test any logic branch that depends on a `true` FHE boolean result. Changing to `2` gives `% 2` which correctly yields either `0` (false) or `1` (true).