### PR TITLE
fix(FHERC20): mark `_transferFromEncrypted` and `_transferEncrypted` as `internal`

### DIFF
--- a/contracts/experimental/token/FHERC20/FHERC20.sol
+++ b/contracts/experimental/token/FHERC20/FHERC20.sol
@@ -63,7 +63,7 @@ contract FHERC20 is IFHERC20, ERC20, Permissioned {
         return _transferFromEncrypted(from, to, FHE.asEuint128(value));
     }
 
-    function _transferFromEncrypted(address from, address to, euint128 value) public virtual returns (euint128) {
+    function _transferFromEncrypted(address from, address to, euint128 value) internal virtual returns (euint128) {
         euint128 val = value;
         euint128 spent = _spendAllowance(from, msg.sender, val);
         return _transferImpl(from, to, spent);
@@ -106,7 +106,7 @@ contract FHERC20 is IFHERC20, ERC20, Permissioned {
     }
 
     // Transfers an amount from the message sender address to the `to` address.
-    function _transferEncrypted(address to, euint128 amount) public returns (euint128) {
+    function _transferEncrypted(address to, euint128 amount) internal returns (euint128) {
         return _transferImpl(msg.sender, to, amount);
     }
 


### PR DESCRIPTION
## Summary

`_transferFromEncrypted` (line 66) and `_transferEncrypted` (line 109) in `FHERC20.sol` are declared `public`, inadvertently exposing internal transfer helpers as part of the contract's external ABI.

## Bug

```solidity
// Before (incorrect)
function _transferFromEncrypted(address from, address to, euint128 value) public virtual returns (euint128)
function _transferEncrypted(address to, euint128 amount) public returns (euint128)
```

The underscore-prefix naming convention in Solidity universally signals internal helpers. Declaring them `public` means:
- Any external actor can invoke `_transferFromEncrypted` or `_transferEncrypted` directly, bypassing any logic intended to be enforced only through the canonical public wrappers.
- Child contracts inheriting `FHERC20` expose these in their ABI, creating unexpected attack surface.
- ABI-generated clients and block explorers will surface these as callable external functions, creating confusion and risk.

## Fix

Change the visibility from `public` to `internal`:

```solidity
// After (correct)
function _transferFromEncrypted(address from, address to, euint128 value) internal virtual returns (euint128)
function _transferEncrypted(address to, euint128 amount) internal returns (euint128)
```

External callers should always go through the canonical `transferEncrypted` and `transferFromEncrypted` wrappers.