### PR TITLE
fix(PermissionedV2): guard against empty project string bypass in `satisfies()`

### DIFF
--- a/contracts/access/PermissionedV2.sol
+++ b/contracts/access/PermissionedV2.sol
@@ -260,11 +260,18 @@ library PermissionV2Utils {
         address addr,
         string memory proj
     ) internal pure returns (bool) {
-        for (uint256 i = 0; i < permission.projects.length; i++) {
-            if (
-                keccak256(abi.encodePacked(proj)) ==
-                keccak256(abi.encodePacked(permission.projects[i]))
-            ) return true;
+        // Only match by project identifier when the contract has a non-empty project string.
+        // An empty project means the contract opts out of project-based access control;
+        // matching "" would allow any permission that includes "" in its projects list to
+        // gain unintended access to every such contract.
+        bool hasProject = bytes(proj).length > 0;
+        if (hasProject) {
+            for (uint256 i = 0; i < permission.projects.length; i++) {
+                if (
+                    keccak256(abi.encodePacked(proj)) ==
+                    keccak256(abi.encodePacked(permission.projects[i]))
+                ) return true;
+            }
         }
         for (uint256 i = 0; i < permission.contracts.length; i++) {
             if (addr == permission.contracts[i]) return true;


### PR DESCRIPTION
## Summary

`satisfies()` in `PermissionV2Utils` performs a string-hash comparison between the contract's `project` identifier and each entry in `permission.projects`. When a contract is deployed with `project = ""` (the documented way to opt out of project-based access control), this comparison matches any permission that includes `""` in its `projects` list — granting unintended cross-contract access.

## Bug

From the constructor NatSpec:
> Use an empty string for no project identifier.

But `satisfies()` does not distinguish an empty `proj` from a real identifier:

```solidity
keccak256(abi.encodePacked("")) == keccak256(abi.encodePacked(""))  // always true
```

Any attacker can craft a permission with `projects = [""]` and gain access to **every** `PermissionedV2`-inheriting contract deployed with an empty `project` string.

## Fix

Skip the project loop entirely when `bytes(proj).length == 0`. Access for such contracts is still possible via the `contracts` allowlist.

```solidity
bool hasProject = bytes(proj).length > 0;
if (hasProject) {
    for (uint256 i = 0; i < permission.projects.length; i++) { ... }
}
```