### PR TITLE
fix(FHERC721): use `ownerOf` instead of `_ownerOf` in `tokenPrivateData`

### DIFF
--- a/contracts/experimental/token/FHERC721/FHERC721.sol
+++ b/contracts/experimental/token/FHERC721/FHERC721.sol
@@ -38,7 +38,7 @@ contract FHERC721 is IFHERC721, Permissioned, ERC721 {
     function tokenPrivateData(
         uint256 tokenId,
         Permission memory auth
-    ) external view onlyPermitted(auth, _ownerOf(tokenId)) returns (string memory) {
+    ) external view onlyPermitted(auth, ownerOf(tokenId)) returns (string memory) {
         return FHE.sealoutput(_privateData[tokenId], auth.publicKey);
     }
 


### PR DESCRIPTION
## Summary

`tokenPrivateData` calls `_ownerOf(tokenId)` (the internal getter) to retrieve the token owner for access control. `_ownerOf` returns `address(0)` when the token does not exist. This allows a permission whose `issuer` is `address(0)` to pass the `onlyPermitted` check and read private data for any non-existent token ID.

## Bug

```solidity
// contracts/experimental/token/FHERC721/FHERC721.sol line 41
function tokenPrivateData(
    uint256 tokenId,
    Permission memory auth
) external view onlyPermitted(auth, _ownerOf(tokenId)) returns (string memory) {
```

**Attack scenario:** An attacker crafts a `Permission` with `issuer = address(0)` and calls `tokenPrivateData` with any unminted `tokenId`. `_ownerOf(tokenId)` returns `address(0)`, so `onlyPermitted(auth, address(0))` passes, and the attacker receives the (zero-initialized) sealed output for that token slot.

## Fix

```solidity
// After
onlyPermitted(auth, ownerOf(tokenId))
```

The public `ownerOf` reverts with `ERC721NonexistentToken` for unminted tokens (OpenZeppelin ERC721 ≥ 5.x), ensuring callers receive a clear error instead of a silent auth bypass.