### PR TITLE
fix(PermissionedV2): declare `version` as `string public constant`

### DIFF
--- a/contracts/access/PermissionedV2.sol
+++ b/contracts/access/PermissionedV2.sol
@@ -96,7 +96,7 @@ contract PermissionedV2 is EIP712 {
     using PermissionV2Utils for PermissionV2;
 
     /// @notice Version of the fhenix permission signature
-    string public version = "v2.0.0";
+    string public constant version = "v2.0.0";
 
     /// @notice This contract's project identifier string. Used in permissions to grant access to all contracts with this identifier.
     string public project;


### PR DESCRIPTION
## Summary

`version` in `PermissionedV2` is declared as a mutable `public` state variable, but it is consumed in the EIP712 domain during construction and should never change.

## Bug

```solidity
// Before
string public version = "v2.0.0";
```

Problems:
1. **Child contract shadowing** — A child contract can re-declare `version` with a different value. The EIP712 domain (captured at construction) keeps the original value, but `version` returns the shadowed value, creating a discrepancy between the stored version and the one used in signature verification.
2. **Wasted storage slot** — A mutable string occupies a storage slot unnecessarily.
3. **Accidental mutation** — Any contract that inherits `PermissionedV2` could inadvertently reset `version`, breaking tooling that relies on it.

## Fix

```solidity
// After
string public constant version = "v2.0.0";
```

A `constant` is inlined at compile time, costs no storage, cannot be overridden, and accurately represents the intended semantics: the version is fixed per deployment.