### PR TITLE
fix(FHERC20): change `wrap`/`unwrap` parameter from `uint32` to `uint128`

### DIFF
--- a/contracts/experimental/token/FHERC20/FHERC20.sol
+++ b/contracts/experimental/token/FHERC20/FHERC20.sol
@@ -69,7 +69,7 @@ contract FHERC20 is IFHERC20, ERC20, Permissioned {
         return _transferImpl(from, to, spent);
     }
 
-    function wrap(uint32 amount) public {
+    function wrap(uint128 amount) public {
         if (balanceOf(msg.sender) < amount) {
             revert ErrorInsufficientFunds();
         }
@@ -80,7 +80,7 @@ contract FHERC20 is IFHERC20, ERC20, Permissioned {
         totalEncryptedSupply = totalEncryptedSupply + eAmount;
     }
 
-    function unwrap(uint32 amount) public {
+    function unwrap(uint128 amount) public {
         euint128 encAmount = FHE.asEuint128(amount);
 
         euint128 amountToUnwrap = FHE.select(_encBalances[msg.sender].gte(encAmount), encAmount, FHE.asEuint128(0));


### PR DESCRIPTION
## Summary

`wrap(uint32 amount)` and `unwrap(uint32 amount)` in `FHERC20.sol` use a `uint32` parameter, but the underlying encrypted balance type is `euint128` (128-bit). This mismatch severely caps single-operation amounts.

## Bug

```solidity
// Before
function wrap(uint32 amount) public { ... }
function unwrap(uint32 amount) public { ... }
```

The `uint32` parameter limits each wrap/unwrap call to at most `2^32 - 1 ≈ 4.29 billion`. For a token with 18 decimal places (the ERC-20 standard), this means a maximum of **~4.29 tokens per operation** — rendering the contract unusable for any standard-scale DeFi use case. The encrypted balance is `euint128`, which can hold up to `2^128 - 1`, making the parameter type the sole bottleneck.

## Fix

```solidity
// After
function wrap(uint128 amount) public { ... }
function unwrap(uint128 amount) public { ... }
```

This aligns the plaintext parameter type with the capacity of the encrypted type and allows wrap/unwrap amounts up to the full 128-bit range without changing any internal logic.