### PR TITLE
fix(genConsole): regenerate the committed Console.sol, not a stale copy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ install:
 
 .PHONY: gen_console
 gen_console: install
-	npx tsc ./scripts/genConsole.ts
+	npx ts-node ./scripts/genConsole.ts
 
 
 .PHONY: gen

--- a/scripts/genConsole.ts
+++ b/scripts/genConsole.ts
@@ -51,9 +51,9 @@ const generateLogFunctions = (n: number): string => {
       .join(", ");
     const methodName = `log(${params})`;
 
-    // Generating external pure function strings
+    // Generating internal pure function strings
     output +=
-      `\tfunction ${methodName} external pure {\n` +
+      `\tfunction ${methodName} internal pure {\n` +
       `    \t_logImpl${n}Params(${conversion});\n` +
       `\t}\n\n`;
   });
@@ -80,7 +80,7 @@ function generateCombinations(types: string[], n: number): string[][] {
 let output = `// SPDX-License-Identifier: MIT
 pragma solidity >=0.8.19 <0.9.0;
 
-import {FheOps, Precompiles} from "./FheOS.sol";
+import {FheOps, Precompiles} from "../../FheOS.sol";
 import "@openzeppelin/contracts/utils/Strings.sol";
 
 library Console {
@@ -140,27 +140,27 @@ library Console {
         _logImpl(_addressToString(p0));
     }
 
-    function logBytes(bytes memory p0) external pure {
+    function logBytes(bytes memory p0) internal pure {
         _logImpl(string(p0));
     }
 
-    function log(int256 p0) external pure {
+    function log(int256 p0) internal pure {
         _logInt(p0);
     }
 
-    function log(uint256 p0) external pure {
+    function log(uint256 p0) internal pure {
         _logUint(p0);
     }
 
-    function log(string memory p0) external pure {
+    function log(string memory p0) internal pure {
        _logImpl(p0);
     }
 
-    function log(bool p0) external pure {
+    function log(bool p0) internal pure {
         _logBool(p0);
     }
 
-    function log(address p0) external pure {
+    function log(address p0) internal pure {
         _logAddress(p0);
     }
 `;
@@ -168,6 +168,6 @@ library Console {
 for (let i = 2; i <= 3; i++) {
   output += generateLogFunctions(i);
 }
-output += "}";
+output += "}\n";
 
-writeFileSync("./contracts/Console.sol", output);
+writeFileSync("./contracts/utils/debug/Console.sol", output);


### PR DESCRIPTION
## Problem

`contracts/utils/debug/Console.sol` is generated by `scripts/genConsole.ts`, but that pipeline has stopped working in two independent ways: the `make` target never executes the generator, and if you run it by hand it writes the wrong file and undoes two deliberate edits.

### 1. `make gen_console` never runs the generator

```makefile
gen_console: install
	npx tsc ./scripts/genConsole.ts
```

`tsc` *transpiles* the script — it does not execute it. I ran the target as-is: `contracts/Console.sol` was not created, and a stray `scripts/genConsole.js` appeared instead. So `make gen` has been a no-op on the artifact.

### 2. The generator has drifted from the artifact in three ways

| Drift | Generator emits | Artifact has | Introduced by |
| --- | --- | --- | --- |
| Output path | `./contracts/Console.sol` | lives at `contracts/utils/debug/Console.sol` | `260d60a` ("CR") — a 100% rename that never reached the generator |
| Import path | `from "./FheOS.sol"` | `from "../../FheOS.sol"` | follows from the same move |
| Visibility | `external pure` (all 156 `log` overloads) | `internal pure` | `d10a7f8` — *"converting Console library functions to internal so that no pre-deployment of the library is needed"* |

Running the generator today therefore does two bad things: it writes a **second, stale `Console.sol`** at the pre-`260d60a` path instead of updating the real one, and its output would revert `d10a7f8` — putting back the requirement to deploy and link `Console` before a consumer can use it, which is exactly what that commit removed.

I confirmed the drift empirically before touching anything: running the generator unchanged produced a 686-line `contracts/Console.sol`, and diffing it against the committed artifact (line endings normalised) showed precisely those three differences and nothing else, plus a missing trailing newline.

## Fix

- **Makefile** — `npx tsc` → `npx ts-node` (already a devDependency at `^10.9.2`), so the target actually generates.
- **`scripts/genConsole.ts`** — write to `./contracts/utils/debug/Console.sol`, emit `../../FheOS.sol`, emit `internal pure` for the log overloads (the 6 in the literal template plus the 150 from `generateLogFunctions`), and emit the trailing newline the committed file has.

No change to the generated artifact itself — see below.

## Verification

With the fix applied, `npx ts-node ./scripts/genConsole.ts` reproduces the checked-in file **byte for byte**:

```
regenerated vs committed: IDENTICAL
  both: 687 lines, 23191 bytes
git diff -- contracts/utils/debug/Console.sol   ->  0 lines
no stray contracts/Console.sol created
```

That is the point of the PR: the generator is now idempotent against what is in the repo, so `make gen` is safe to run and future edits to `Console.sol` can go through the generator instead of by hand. Because the artifact is unchanged, this PR touches only the two source files — nothing regenerates in the diff.

Note on what I could not run: this repo's Hardhat (2.19.3) loads a native `solidity-analyzer` binary that an Application Control policy blocks on my machine, so I could not run `pnpm compile` or the test suite. That does not affect the claims above — they are about the generator and its output, both verified directly — but CI compiling `Console.sol` is still the authoritative check that the artifact is untouched.

## Adjacent, deliberately not changed

`make install` runs `npm i` while the repo is pnpm-based (`pnpm-lock.yaml`, and CI uses `pnpm install --frozen-lockfile`). Since `gen_console` depends on `install`, `make gen` will resolve dependencies outside the lockfile. That is a real papercut — installing outside the lockfile here resolves `@openzeppelin/contracts` to a 5.6.x that needs `pragma ^0.8.24` and no longer compiles against the pinned solc `0.8.20` — but it is a separate concern from the generator, so I left it alone. Happy to fold it in if you'd like.

## Overlap

#137 also edits `scripts/genConsole.ts`, but only the `// Generate and print the log functions for 2 to 4 parameters` comment near line 167; this PR touches lines 51–56, 83, 143–163 and 171–173, so the two do not conflict.
